### PR TITLE
Add initial operator descriptor

### DIFF
--- a/backend/core/core/models/operators.py
+++ b/backend/core/core/models/operators.py
@@ -15,3 +15,30 @@ class OperatorVal(BaseModel):
     uri: URI
     status: OperatorStatus
     pipeline_id: str | None = None
+
+
+class OperatorInput(BaseModel):
+    label: str # Human readable name of the input
+    description: str # Human readable description of the input
+
+
+class OperatorOutput(BaseModel):
+    label: str # Human readable name of the output
+    description: str # Human readable description of the output
+
+
+class OperatorParameter(BaseModel):
+    label: str # Human readable name of the parameter
+    description: str # Human readable description of the parameter
+    type: str # Type of the parameter
+    default: str # Default value of the parameter
+    required: bool # If the parameter is required
+
+
+class Operator(BaseModel):
+    label: str # Human readable name of the operator
+    description: str # Human readable description of the operator
+    image: str # Contain image for operator
+    inputs: list[OperatorInput] # List of inputs
+    outputs: list[OperatorOutput] # List of outputs
+    parameters: dict[str, OperatorParameter] # List of parameters


### PR DESCRIPTION
This adds a "straw man" operator descriptor that provides some of the information that will be needed by the UI to present the available operators. 