### PR TITLE
add pvapy operators

### DIFF
--- a/frontend/interactEM/src/operators/operators.json
+++ b/frontend/interactEM/src/operators/operators.json
@@ -335,5 +335,35 @@
     "image": "interactem/error:latest",
     "label": "Error test",
     "description": "Generates an error"
+  },
+  {
+    "id": "12345678-1234-1234-1234-1432567830cd",
+    "image": "interactem/pva-converter",
+    "label": "PVA Converter",
+    "description": "Consumes PVA and sends it to the next operator",
+    "outputs": [
+      {
+        "name": "out",
+        "label": "The output",
+        "type": "PvObject",
+        "description": "Sparse scan"
+      }
+    ],
+    "parameters": [
+      {
+        "name": "env_file",
+        "label": ".env file",
+        "type": "mount",
+        "default": "~/Documents/gits/interactEM/operators/pva-converter/.env",
+        "description": "Environment file for pvaPy Consumer",
+        "required": true
+      }
+    ]
+  },
+  {
+    "id": "12345678-1234-1234-1234-1432563830cd",
+    "image": "interactem/pvapy-ad-sim-server",
+    "label": "PVA Area Detector Server",
+    "description": "Generates PVAs"
   }
 ]

--- a/operators/build_all.sh
+++ b/operators/build_all.sh
@@ -21,6 +21,8 @@ build_dirs=(
     "image-display"
     "random-image"
     "sparse-frame-image-converter"
+    "pva-converter"
+    "pvapy-ad-sim-server"
 )
 
 # Function to check if a directory is in the build_dirs array

--- a/operators/pva-converter/.env
+++ b/operators/pva-converter/.env
@@ -1,0 +1,2 @@
+inputChannel="pvapy:image"
+EPICS_PVA_NAME_SERVERS="127.0.0.1:11111"

--- a/operators/pva-converter/Containerfile
+++ b/operators/pva-converter/Containerfile
@@ -1,0 +1,7 @@
+FROM interactem/operator
+
+RUN pip install pvapy
+
+EXPOSE 11111
+
+COPY ./run.py /app/run.py

--- a/operators/pva-converter/run.py
+++ b/operators/pva-converter/run.py
@@ -1,0 +1,155 @@
+import os
+import time
+from typing import Any
+
+import numpy as np
+import pvaccess as pva
+from pvaccess import PvObject as PvaPvObject
+from pvapy.hpc.dataConsumer import DataConsumer
+from pydantic import BaseModel, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from core.logger import get_logger
+from core.models.messages import BytesMessage, MessageHeader, MessageSubject
+from operators.operator import dependencies, operator
+
+logger = get_logger(level="DEBUG")
+
+AttributeName = str
+
+
+class ValueDef(BaseModel):
+    value: Any | None = None
+
+
+class AttributeDictValue(BaseModel):
+    value: tuple[ValueDef, ValueDef] = (ValueDef(), ValueDef())
+    source: str
+    sourceType: int
+    descriptor: str
+
+    @field_validator("value")
+    @classmethod
+    def check_value(cls, v):
+        if len(v) != 2:
+            raise ValueError("Value must have exactly two elements.")
+        return v
+
+    def get_value(self) -> str | int | float | None:
+        if self.value[0].value is None:
+            return
+        return self.value[0].value
+
+    def update_value(self, new_value: ValueDef):
+        self.value = (new_value, self.value[1])
+
+
+class Attribute(AttributeDictValue):
+    name: AttributeName
+
+
+class PvObjectMeta(BaseModel):
+    uid: int
+    attrs: dict[str, Attribute]
+    shape: tuple[int, int]  # (ny, nx)
+
+    @classmethod
+    def from_pv(cls, pv: PvaPvObject) -> "PvObjectMeta":
+        uid = int(pv["uniqueId"])
+
+        dims = pv["dimension"]
+        if len(dims) > 2:
+            raise ValueError("Image cannot have dimensions larger than 2.")
+
+        attrs = {a["name"]: a for a in pv["attribute"]}
+
+        nx = int(dims[0]["size"])
+        ny = int(dims[1]["size"])
+
+        return cls(uid=uid, attrs=attrs, shape=(ny, nx))
+
+
+def get_image(pv: PvaPvObject, meta: PvObjectMeta) -> np.ndarray:
+    fieldKey = pv.getSelectedUnionFieldName()
+    image: np.ndarray = np.array(pv["value"][0][fieldKey], copy=False).reshape(
+        meta.shape[0], meta.shape[1]
+    )
+    return image
+
+
+env_file = "/mnt/env_file"
+
+
+class DataConsumerConfig(BaseSettings):
+    model_config = SettingsConfigDict(env_file=env_file, extra="ignore")
+    monitorQueueSize: int = 0
+    consumerId: str = "0"
+    inputChannel: str
+    providerType: str = "pva"
+    objectIdField: str = "uniqueId"
+
+
+cfg = DataConsumerConfig()  # type: ignore
+
+
+class EpicsEnvVars(BaseSettings):
+    model_config = SettingsConfigDict(env_file=env_file, extra="ignore")
+    EPICS_PVA_NAME_SERVERS: str = "127.0.0.1:11111"
+    EPICS_PVA_AUTO_ADDR_LIST: str = "NO"
+    PVAPY_EPICS_LOG_LEVEL: str = "0"
+
+
+epics_env = EpicsEnvVars()
+
+
+class DataConsumerWrapper(DataConsumer):
+    def __init__(self, cfg: DataConsumerConfig):
+        super().__init__(**cfg.model_dump())
+        self.logger = logger
+
+    def processFromQueue(self) -> tuple[PvObjectMeta, np.ndarray] | None:
+        if self.pvObjectQueue is None:
+            return
+        try:
+            pvObject = self.pvObjectQueue.get()
+            meta = PvObjectMeta.from_pv(pvObject)
+            image = get_image(pvObject, meta)
+            return (meta, image)
+        except pva.QueueEmpty:
+            time.sleep(0.05)
+            pass
+        except Exception as e:
+            self.logger.error(f"Error processing PV object: {e}")
+            self.logger.exception(e)
+            return
+
+
+consumer = DataConsumerWrapper(cfg)
+
+
+@dependencies
+def deps():
+    os.environ["PVAPY_EPICS_LOG_LEVEL"] = epics_env.PVAPY_EPICS_LOG_LEVEL
+    os.environ["EPICS_PVA_AUTO_ADDR_LIST"] = epics_env.EPICS_PVA_AUTO_ADDR_LIST
+    os.environ["EPICS_PVA_NAME_SERVERS"] = epics_env.EPICS_PVA_NAME_SERVERS
+    logger.info(f"EPICS_PVA_NAME_SERVERS: {epics_env.EPICS_PVA_NAME_SERVERS}")
+    global consumer
+    consumer.start()
+    yield
+    consumer.stop()
+
+
+@operator
+def pva_converter(
+    inputs: BytesMessage | None, parameters: dict[str, Any]
+) -> BytesMessage | None:
+    global consumer
+    result = consumer.processFromQueue()
+    if result is None:
+        return
+    meta, image = result
+    meta = meta.model_dump()
+    data = image.tobytes()
+    logger.info(meta)
+    header = MessageHeader(subject=MessageSubject.BYTES, meta=meta)
+    return BytesMessage(header=header, data=data)

--- a/operators/pvapy-ad-sim-server/Containerfile
+++ b/operators/pvapy-ad-sim-server/Containerfile
@@ -1,0 +1,9 @@
+FROM interactem/operator
+
+RUN pip install pvapy
+
+ENV EPICS_PVA_SERVER_PORT 11111
+
+COPY ./run.sh /app/run.sh
+
+ENTRYPOINT [ "/app/run.sh" ]

--- a/operators/pvapy-ad-sim-server/run.sh
+++ b/operators/pvapy-ad-sim-server/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+DET_SIZE_X=2560
+DET_SIZE_Y=2160
+FRAMES_PER_SECOND=1
+DATA_TYPE=uint8
+PV_NAME=pvapy:image
+REPORT_TIME=30000
+CACHE_SIZE=100
+
+pvapy-ad-sim-server -cn $PV_NAME -nx $DET_SIZE_X -ny $DET_SIZE_Y -dt $DATA_TYPE --disable-curses -rt $REPORT_TIME -fps $FRAMES_PER_SECOND -cs $CACHE_SIZE


### PR DESCRIPTION
- adds pvayp-ad-sim-server, which simulates area detector data. This is for testing purposes, and hardcodes the env var `EPICS_PVA_SERVER_PORT=11111`.
- adds pvapy-converter, which takes data from a PVA server and converts it into our framework. Note the env vars (`EPICS_PVA_NAME_SERVERS` in particular) need to be set properly.

Note: this was a pain to get working because there is something funky with EPICS + macOS for discovery. I tried grabbing frames from pvapy-ad-sim-server running outside podman (on macos host), and there seems to be some connection (used `PVAPY_EPICS_LOG_LEVEL=0) but the frame is never received. This DOES work on x86 (tested on perlmutter), so we should be able to receive detector frames from some upstream source that runs outside of a container in production...