### PR TITLE
add AnyWebsocketUrl to NATS_SERVER_URL everywhere

### DIFF
--- a/backend/agent/interactem/agent/config.py
+++ b/backend/agent/interactem/agent/config.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from pydantic import AnyWebsocketUrl, Field, NatsDsn, model_validator
+from pydantic import AnyWebsocketUrl, NatsDsn, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -9,9 +9,9 @@ class Settings(BaseSettings):
     LOCAL: bool = False
     DOCKER_COMPATIBILITY_MODE: bool = False
     PODMAN_SERVICE_URI: str | None = None
-    NATS_SERVER_URL: AnyWebsocketUrl | NatsDsn = Field(default="nats://localhost:4222")
-    NATS_SERVER_URL_IN_CONTAINER: AnyWebsocketUrl | NatsDsn = Field(
-        default="nats://nats1:4222"
+    NATS_SERVER_URL: AnyWebsocketUrl | NatsDsn = NatsDsn("nats://localhost:4222")
+    NATS_SERVER_URL_IN_CONTAINER: AnyWebsocketUrl | NatsDsn = NatsDsn(
+        "nats://nats1:4222"
     )
     AGENT_TAGS: list[str] = []
     MOUNT_LOCAL_REPO: bool = False

--- a/backend/app/interactem/app/core/config.py
+++ b/backend/app/interactem/app/core/config.py
@@ -7,6 +7,7 @@ from urllib.parse import quote_plus
 from nats.aio.client import Client as NATSClient
 from pydantic import (
     AnyUrl,
+    AnyWebsocketUrl,
     BeforeValidator,
     Field,
     HttpUrl,
@@ -122,7 +123,7 @@ class Settings(BaseSettings):
         return self
 
     # NATS
-    NATS_SERVER_URL: NatsDsn = Field(default="nats://nats1:4222")
+    NATS_SERVER_URL: AnyWebsocketUrl | NatsDsn = NatsDsn("nats://nats1:4222")
 
     # External auth
     EXTERNAL_SECRET_KEY: str

--- a/backend/launcher/interactem/launcher/config.py
+++ b/backend/launcher/interactem/launcher/config.py
@@ -1,13 +1,13 @@
 import shlex
 from pathlib import Path
 
-from pydantic import NatsDsn, model_validator
+from pydantic import AnyWebsocketUrl, NatsDsn, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
-    NATS_SERVER_URL: NatsDsn = NatsDsn("nats://localhost:4222")
+    NATS_SERVER_URL: AnyWebsocketUrl | NatsDsn = NatsDsn("nats://localhost:4222")
     SFAPI_KEY_PATH: Path = Path("/secrets/sfapi.pem")
     CONDA_ENV: Path | str
     ENV_FILE_PATH: Path

--- a/backend/metrics/interactem/metrics/config.py
+++ b/backend/metrics/interactem/metrics/config.py
@@ -1,10 +1,10 @@
-from pydantic import Field, NatsDsn
+from pydantic import AnyWebsocketUrl, NatsDsn
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=None)
-    NATS_SERVER_URL: NatsDsn = Field(default="nats://localhost:4222")
+    NATS_SERVER_URL: AnyWebsocketUrl | NatsDsn = NatsDsn("nats://localhost:4222")
 
 
 cfg = Settings()

--- a/backend/operators/interactem/operators/config.py
+++ b/backend/operators/interactem/operators/config.py
@@ -1,10 +1,10 @@
-from pydantic import Field, NatsDsn
+from pydantic import AnyWebsocketUrl, NatsDsn
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=None)
-    NATS_SERVER_URL: NatsDsn = Field(default="nats://localhost:4222")
+    NATS_SERVER_URL: AnyWebsocketUrl | NatsDsn = NatsDsn("nats://localhost:4222")
 
 
 cfg = Settings()

--- a/backend/orchestrator/interactem/orchestrator/config.py
+++ b/backend/orchestrator/interactem/orchestrator/config.py
@@ -1,10 +1,10 @@
-from pydantic import Field, NatsDsn
+from pydantic import AnyWebsocketUrl, NatsDsn
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=None)
-    NATS_SERVER_URL: NatsDsn = Field(default="nats://localhost:4222")
+    NATS_SERVER_URL: AnyWebsocketUrl | NatsDsn = NatsDsn("nats://localhost:4222")
 
 
 cfg = Settings()


### PR DESCRIPTION
The problem is that when you pull in the environment variable as a string, it will validate and coerce the str() representation of the NatsDsnUrl with a port (default at 4222). Since we are connecting to wss:// ....  without a port, we want to ensure that that port doesn't get added.