### PR TITLE
Operator updates

### DIFF
--- a/operators/beam-compensation/Containerfile
+++ b/operators/beam-compensation/Containerfile
@@ -2,5 +2,7 @@ FROM ghcr.io/nersc/interactem/operator
 
 RUN pip install scipy ncempy stempy
 
+COPY ./run.py /app/run.py
+
 RUN mkdir -p /output
 RUN mkdir -p /vacuum_scan

--- a/operators/data-replay/Containerfile
+++ b/operators/data-replay/Containerfile
@@ -2,5 +2,7 @@ FROM ghcr.io/nersc/interactem/operator
 
 RUN pip install scipy ncempy stempy
 
+COPY ./run.py /app/run.py
+
 RUN mkdir -p /output
 RUN mkdir -p /raw_data

--- a/operators/data-replay/operator.json
+++ b/operators/data-replay/operator.json
@@ -19,6 +19,14 @@
       "default": "~/ncem_raw_data",
       "description": "This is where the raw data files (*.data) are located",
       "required": true
+    },
+    {
+      "name": "scan_num",
+      "label": "Scan number",
+      "type": "int",
+      "default": "0",
+      "description": "The scan number to be processed",
+      "required": true
     }
   ],
   "tags": [

--- a/operators/data-replay/run.py
+++ b/operators/data-replay/run.py
@@ -25,36 +25,59 @@ class FrameHeader(BaseModel):
 
 # Setup data paths
 path = Path(f"{DATA_DIRECTORY}/raw_data_dir")
-scan_num = 684
-scan_name_path = Path(f"data_scan{scan_num:010}*.data")
-files = path.glob(str(scan_name_path))
-iFiles = sorted(files)
 
-# Read the first frame to get the scan dimensions
-iFiles_str = [str(ii) for ii in iFiles]
-reader = stio.reader(iFiles_str, stio.FileVersion.VERSION5, backend="multi-pass")
-block0 = reader.read_frames(0)
-scan_dimensions = block0[0].header.scan_dimensions
-n_cols, n_rows = scan_dimensions
-frame_dimensions = block0[0].header.frame_dimensions
-logger.info(f"Sending scan {scan_num} with dimensions {scan_dimensions}.")
-scan_positions = range(scan_dimensions[0] * scan_dimensions[1])
-scan_positions_cycle = itertools.cycle(scan_positions)
-scan_num = -1
+# Initialize global variables
+reader = None
+scan_positions_cycle = None
+n_cols = 0
+n_rows = 0
 send_count = 0
+current_scan_num = -1
+
+
+def read_scan_metadata(scan_num: int) -> tuple[stio.reader, itertools.cycle, int, int]:
+    scan_name_path = Path(f"data_scan{scan_num:010}*.data")
+    files = path.glob(str(scan_name_path))
+    iFiles = sorted(files)
+    iFiles_str = [str(ii) for ii in iFiles]
+    reader = stio.reader(iFiles_str, stio.FileVersion.VERSION5, backend="multi-pass")
+    block0 = reader.read_frames(0)
+    scan_dimensions = block0[0].header.scan_dimensions
+    n_cols, n_rows = scan_dimensions
+    logger.info(f"Sending scan {scan_num} with dimensions {scan_dimensions}.")
+    scan_positions = range(scan_dimensions[0] * scan_dimensions[1])
+    scan_positions_cycle = itertools.cycle(scan_positions)
+    return reader, scan_positions_cycle, n_cols, n_rows
 
 
 @operator
 def save(
     inputs: BytesMessage | None, parameters: dict[str, Any]
 ) -> BytesMessage | None:
-    global reader, scan_positions_cycle, scan_num, send_count
+    global reader, scan_positions_cycle, n_cols, n_rows, send_count, current_scan_num
+    
+    scan_num = parameters.get("scan_num", None)
+    if scan_num is None:
+        logger.error("Missing scan_num parameter.")
+        raise ValueError("Missing scan_num parameter.")
+    
+    # Only read new metadata when the scan number changes
+    if scan_num != current_scan_num:
+        logger.info(f"New scan number detected: {scan_num}, loading metadata")
+        reader, scan_positions_cycle, n_cols, n_rows = read_scan_metadata(scan_num)
+        current_scan_num = scan_num
+        send_count = 0
+    
+    if scan_positions_cycle is None:
+        _msg = "scan_positions_cycle is None. Make sure metadata is loaded properly."
+        logger.error(_msg)
+        raise ValueError("scan_positions_cycle is None. Make sure metadata is loaded properly.")
+        
     position = next(scan_positions_cycle)
-    if position == 0:
-        logger.info(f"Finished scan {scan_num}")
+    if position == 0 and send_count > 0:
+        logger.info(f"Completed full cycle of scan {scan_num}")
         logger.info(f"Sent {send_count} frames.")
-        scan_num += 1
-        logger.info(f"Starting scan {scan_num}")
+    
     block = reader.read_frames(position)
     row_idx, col_idx = np.unravel_index(position, (n_rows, n_cols))
     try:

--- a/operators/pvapy-ad-sim-server/Containerfile
+++ b/operators/pvapy-ad-sim-server/Containerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/nersc/interactem/operator
 
 RUN pip install pvapy
 
-ENV EPICS_PVA_SERVER_PORT 11111
+ENV EPICS_PVA_SERVER_PORT=11111
 
 COPY ./run.sh /app/run.sh
 


### PR DESCRIPTION
- copy run.py into beam-compensation and data-replay (so they actually do something....)
- Fix initialization of data replay
- add scan_number parameter to data-replay, to choose scan number. In some future iteration, it might be cool to be able to read a directory and update the frontend with the choices of scan number, but this is a larger change that I want to punt on for now.