### PR TITLE
init docker bake

### DIFF
--- a/docker/bake.sh
+++ b/docker/bake.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname "$0")
+ROOT_DIR=$(git rev-parse --show-toplevel)
+TAG=$(git rev-parse --short=6 HEAD)
+DOCKER=${1:-docker}
+
+cd $ROOT_DIR
+
+# Build all images using Docker Bake
+echo "Building all images with tag $TAG..."
+BUILDX_BAKE_ENTITLEMENTS_FS=0 $DOCKER buildx bake --file $ROOT_DIR/docker/docker-bake.hcl --set *.args.TAG=$TAG
+
+if [ $? -ne 0 ]; then
+    echo "Failed to build images"
+    exit 1
+fi
+
+echo "All builds completed successfully"

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -1,0 +1,99 @@
+variable "TAG" {
+  default = "latest"
+}
+
+variable "REGISTRY" {
+  default = "ghcr.io/nersc/interactem"
+}
+
+// Base platform definition
+target "platform" {
+  platforms = ["linux/amd64", "linux/arm64"]
+}
+
+// Base image (parent for service images)
+target "base" {
+  inherits = ["platform"]
+  context = "backend/"
+  dockerfile = "../docker/Dockerfile.base"
+  tags = [
+    "${REGISTRY}/interactem:${TAG}",
+    "${REGISTRY}/interactem:latest",
+  ]
+}
+
+// Service definitions
+target "operator" {
+  inherits = ["platform"]
+  context = "backend/"
+  dockerfile = "../docker/Dockerfile.operator"
+  tags = [
+    "${REGISTRY}/operator:${TAG}",
+    "${REGISTRY}/operator:latest",
+  ]
+  depends_on = ["base"]
+}
+
+target "callout" {
+  inherits = ["platform"]
+  context = "backend/"
+  dockerfile = "../docker/Dockerfile.callout"
+  tags = [
+    "${REGISTRY}/callout:${TAG}",
+    "${REGISTRY}/callout:latest",
+  ]
+  depends_on = ["base"]
+}
+
+target "fastapi" {
+  inherits = ["platform"]
+  context = "backend/"
+  dockerfile = "../docker/Dockerfile.fastapi"
+  tags = [
+    "${REGISTRY}/fastapi:${TAG}",
+    "${REGISTRY}/fastapi:latest",
+  ]
+  depends_on = ["base"]
+}
+
+target "launcher" {
+  inherits = ["platform"]
+  context = "backend/"
+  dockerfile = "../docker/Dockerfile.launcher"
+  tags = [
+    "${REGISTRY}/launcher:${TAG}",
+    "${REGISTRY}/launcher:latest",
+  ]
+  depends_on = ["base"]
+}
+
+target "orchestrator" {
+  inherits = ["platform"]
+  context = "backend/"
+  dockerfile = "../docker/Dockerfile.orchestrator"
+  tags = [
+    "${REGISTRY}/orchestrator:${TAG}",
+    "${REGISTRY}/orchestrator:latest",
+  ]
+  depends_on = ["base"]
+}
+
+target "frontend" {
+  inherits = ["platform"]
+  context = "frontend/"
+  dockerfile = "../docker/Dockerfile.frontend"
+  tags = [
+    "${REGISTRY}/frontend:${TAG}",
+    "${REGISTRY}/frontend:latest",
+  ]
+}
+
+// Default target group
+group "default" {
+  targets = ["base", "operator", "callout", "fastapi", "launcher", "orchestrator", "frontend"]
+}
+
+// Production target group
+group "prod" {
+  targets = ["base", "operator", "callout", "fastapi", "launcher", "orchestrator", "frontend"]
+}


### PR DESCRIPTION
- much faster builds for local dev
- much cleaner than build, but no podman support. leaving both for now.
- future PR could allow us to do something for only pushing amd64 images up using bake
- Good for future CI...