### PR TITLE
Data replayer operator: fix param not being converted to int

### DIFF
--- a/operators/data-replay/run.py
+++ b/operators/data-replay/run.py
@@ -36,8 +36,15 @@ current_scan_num = -1
 
 
 def read_scan_metadata(scan_num: int) -> tuple[stio.reader, itertools.cycle, int, int]:
-    scan_name_path = Path(f"data_scan{scan_num:010}*.data")
-    files = path.glob(str(scan_name_path))
+    scan_name_path = f"data_scan{scan_num:010d}_*.data"
+    logger.info(f"Looking for files with pattern: {scan_name_path} in {path}")
+    files = list(path.glob(scan_name_path))
+    logger.info(f"Found {len(files)} files for scan {scan_num}.")
+
+    if not files:
+        logger.info(f"Available scan files: {list(path.glob('data_scan*'))[:5]}...")
+        raise FileNotFoundError(f"No files found for scan {scan_num} in {path}")
+        
     iFiles = sorted(files)
     iFiles_str = [str(ii) for ii in iFiles]
     reader = stio.reader(iFiles_str, stio.FileVersion.VERSION5, backend="multi-pass")
@@ -57,6 +64,7 @@ def save(
     global reader, scan_positions_cycle, n_cols, n_rows, send_count, current_scan_num
     
     scan_num = parameters.get("scan_num", None)
+    scan_num = int(scan_num) if scan_num is not None else None
     if scan_num is None:
         logger.error("Missing scan_num parameter.")
         raise ValueError("Missing scan_num parameter.")

--- a/operators/electron-count/Containerfile
+++ b/operators/electron-count/Containerfile
@@ -1,34 +1,20 @@
 FROM ghcr.io/nersc/interactem/operator AS operator-base
 
 # Main build using stempy as the base
-FROM samwelborn/stempy:py310-f685f4d
+FROM docker.io/samwelborn/stempy:py310-f685f4d
 
 WORKDIR /app/
-
-RUN apt-get update && \
-    apt-get install -y curl && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/cache/apt/archives/* 
-
-# Install Poetry
-RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/opt/poetry python && \
-    cd /usr/local/bin && \
-    ln -s /opt/poetry/bin/poetry && \
-    poetry config virtualenvs.create false
 
 # Copy the interactem operator files from the base image
 COPY --from=operator-base /interactem/operators /interactem/operators
 COPY --from=operator-base /interactem/core /interactem/core
 
-# Install additional dependencies needed for this specific operator
-RUN pip install scipy
+RUN cd /interactem/operators/ && pip install . scipy
 
 # Copy the electron-count specific run script
 COPY ./run.py /app/run.py
 
 # Set Python path
-ENV PYTHONPATH=/interactem/operators
 ENV PYTHONUNBUFFERED=1
 
 # Copy the startup script


### PR DESCRIPTION
My previous fix didn't work for this operator. Scan number was being pulled in as a string and glob didn't work correctly.

Also remove the reinstallation of poetry in the containerfile.