### PR TITLE
Refactor agent with faststream + stamina

### DIFF
--- a/backend/agent/interactem/agent/agent.py
+++ b/backend/agent/interactem/agent/agent.py
@@ -259,6 +259,7 @@ class Agent:
         self.agent_val.status = AgentStatus.SHUTTING_DOWN
         if self.agent_kv:
             await self.agent_kv.update_now()
+        self._shutdown_event.set()
 
         for task in self._task_refs:
             task.cancel()

--- a/backend/agent/interactem/agent/agent.py
+++ b/backend/agent/interactem/agent/agent.py
@@ -1,56 +1,41 @@
 import asyncio.subprocess
 import json
 import os
-import signal
 import tempfile
 import time
 import uuid
 from collections.abc import Coroutine
 from typing import Any
 
-import nats
-import nats.errors
-import nats.js
-import nats.js.errors
 import podman
 import podman.errors
-from nats.aio.client import Client as NATSClient
-from nats.js import JetStreamContext
+import stamina
+from faststream.nats import NatsBroker
+from faststream.nats.publisher.asyncapi import AsyncAPIPublisher
 from podman.domain.containers import Container
-from pydantic import ValidationError
+from stamina.instrumentation import set_on_retry_hooks
 
 from interactem.core.constants import (
     OPERATOR_ID_ENV_VAR,
     STREAM_OPERATORS,
+    STREAM_PARAMETERS,
     STREAM_PARAMETERS_UPDATE,
 )
 from interactem.core.constants.mounts import CORE_MOUNT, OPERATORS_MOUNT
 from interactem.core.logger import get_logger
 from interactem.core.models.agent import AgentStatus, AgentVal
-from interactem.core.models.operators import OperatorParameter, ParameterType
+from interactem.core.models.operators import (
+    OperatorParameter,
+    ParameterType,
+)
 from interactem.core.models.pipeline import (
     OperatorJSON,
     PipelineAssignment,
-    PipelineJSON,
     PodmanMount,
     PodmanMountType,
 )
 from interactem.core.models.uri import URI, CommBackend, URILocation
-from interactem.core.nats import (
-    create_or_update_stream,
-    nc,
-    publish_error,
-)
-from interactem.core.nats.config import (
-    AGENTS_STREAM_CONFIG,
-    NOTIFICATIONS_STREAM_CONFIG,
-    OPERATORS_STREAM_CONFIG,
-    PARAMETERS_STREAM_CONFIG,
-)
-from interactem.core.nats.consumers import (
-    create_agent_consumer,
-    create_agent_parameter_consumer,
-)
+from interactem.core.nats.consumers import PARAMETER_CONSUMER_CONFIG
 from interactem.core.nats.kv import InteractemBucket, KeyValueLoop
 from interactem.core.pipeline import Pipeline
 from interactem.core.util import create_task_with_ref
@@ -75,6 +60,13 @@ else:
 
 logger = get_logger()
 
+
+def log_hook(details: stamina.instrumentation.RetryDetails) -> None:
+    logger.warning(f"Retry details: {details}")
+
+
+set_on_retry_hooks([log_hook])
+
 GLOBAL_ENV = {k: str(v) for k, v in cfg.model_dump().items()}
 GLOBAL_ENV["NATS_SERVER_URL"] = GLOBAL_ENV["NATS_SERVER_URL_IN_CONTAINER"]
 
@@ -86,9 +78,35 @@ OPERATOR_CREDS_MOUNT = PodmanMount(
 )
 
 
+class ContainerTracker:
+    def __init__(
+        self,
+        container: Container,
+        operator: OperatorJSON,
+    ):
+        self.container = container
+        self.operator = operator
+        self.marked_for_restart = False
+        self.mount_parameter_tasks: list[asyncio.Task] = []
+
+    def mark(self):
+        self.marked_for_restart = True
+
+    def unmark(self):
+        self.marked_for_restart = False
+
+    def add_parameter_task(self, task: asyncio.Task):
+        self.mount_parameter_tasks.append(task)
+
+    def __del__(self):
+        for task in self.mount_parameter_tasks:
+            task.cancel()
+        self.mount_parameter_tasks.clear()
+
+
 class Agent:
-    def __init__(self):
-        self.id = uuid.uuid4()
+    def __init__(self, id: uuid.UUID, broker: NatsBroker):
+        self.id = id
         self.pipeline: Pipeline | None = None
         self.my_operator_ids: list[uuid.UUID] = []
         self.start_time = time.time()
@@ -103,9 +121,18 @@ class Agent:
                 f"unix://{self._podman_service_dir.name}/podman.sock"
             )
 
+        # Broker attributes used for NATS connections
+        assert broker.stream, "JetStream not initialized"
+        assert broker._connection, "NATS connection not initialized"
+        self.broker = broker
+        self.nc = broker._connection
+        self.js = broker.stream
+
+        # this is set in the broker code
+        self.error_publisher: AsyncAPIPublisher
+
         self._shutdown_event = asyncio.Event()
-        self.nc: NATSClient | None = None
-        self.js: JetStreamContext | None = None
+
         self.agent_val: AgentVal = AgentVal(
             name=cfg.AGENT_NAME,
             tags=cfg.AGENT_TAGS,
@@ -118,9 +145,9 @@ class Agent:
             status=AgentStatus.INITIALIZING,
             networks=cfg.AGENT_NETWORKS,
         )
-        self.agent_kv: KeyValueLoop[AgentVal] | None = None
-        self.server_task: asyncio.Task | None = None
-        self.watch_tasks: dict[uuid.UUID, asyncio.Task] = {}
+        self.agent_kv: KeyValueLoop[AgentVal]
+        self.container_trackers: dict[uuid.UUID, ContainerTracker] = {}
+        self.container_monitor_task: asyncio.Task | None = None
         self.task_refs: set[asyncio.Task] = set()
 
     async def _start_podman_service(self, create_process=False):
@@ -181,19 +208,11 @@ class Agent:
             # Run the tasks concurrently
             await asyncio.gather(*tasks)
 
+        self.container_trackers = {}
+
     async def run(self):
         logger.info(f"Starting agent with configuration: {cfg.model_dump()}")
-        await asyncio.gather(
-            *[self.setup_signal_handlers(), self._start_podman_service()]
-        )
-
-        self.nc = await nc(servers=[str(cfg.NATS_SERVER_URL)], name=f"agent-{self.id}")
-        self.js = self.nc.jetstream()
-
-        await create_or_update_stream(PARAMETERS_STREAM_CONFIG, self.js)
-        await create_or_update_stream(AGENTS_STREAM_CONFIG, self.js)
-        await create_or_update_stream(OPERATORS_STREAM_CONFIG, self.js)
-        await create_or_update_stream(NOTIFICATIONS_STREAM_CONFIG, self.js)
+        await self._start_podman_service()
 
         self.agent_val.status = AgentStatus.IDLE
 
@@ -209,11 +228,34 @@ class Agent:
         self.agent_kv.add_or_update_value(self.id, self.agent_val)
 
         await self.agent_kv.start()
+        self.container_monitor_task = await asyncio.create_task(
+            self.monitor_containers()
+        )
 
-        self.server_task = self.create_task(self.server_loop())
+    async def receive_assignment(self, assignment: PipelineAssignment):
+        try:
+            self.pipeline = Pipeline.from_pipeline(assignment.pipeline)
+            self.my_operator_ids = assignment.operators_assigned
+            self.agent_val.operator_assignments = assignment.operators_assigned
 
-        await self._shutdown_event.wait()
-        await self.shutdown()
+            logger.info(f"Operators assigned: {self.my_operator_ids}")
+            self.agent_val.status = AgentStatus.BUSY
+            self.agent_val.status_message = "Cleaning up containers..."
+            await self.agent_kv.update_now()
+            await self._cleanup_containers()
+            self.agent_val.status_message = "Starting operators..."
+            await self.agent_kv.update_now()
+            await self.start_operators()
+            self.agent_val.status_message = "Operators started..."
+            self.agent_val.status = AgentStatus.IDLE
+            await self.agent_kv.update_now()
+        except Exception as e:
+            self.agent_val.status = AgentStatus.ERROR
+            _msg = f"Failed to start operators: {e}"
+            self.agent_val.add_error(_msg)
+            await self.agent_kv.update_now()
+            await self.error_publisher.publish(_msg)
+            logger.exception(_msg)
 
     def _update_agent_state(self) -> None:
         self.agent_val.operator_assignments = self.my_operator_ids
@@ -226,13 +268,10 @@ class Agent:
         if self.agent_kv:
             await self.agent_kv.update_now()
 
-        if self.server_task:
-            logger.info("Cancelling server task...")
-            self.server_task.cancel()
-            try:
-                await self.server_task
-            except asyncio.CancelledError:
-                logger.info("Server task cancelled successfully")
+        for task in self.task_refs:
+            task.cancel()
+        await asyncio.gather(*self.task_refs, return_exceptions=True)
+        self.task_refs.clear()
 
         await self._cleanup_containers()
         await self._stop_podman_service()
@@ -240,116 +279,23 @@ class Agent:
         if self.agent_kv:
             await self.agent_kv.stop()
 
-        if self.nc:
-            await self.nc.close()
-
-
         logger.info("Agent shut down successfully.")
 
-    async def server_loop(self):
-        logger.info("Server loop running...")
-        if not self.nc or not self.js:
-            logger.error("NATS connection not established. Exiting server loop.")
-            return
-
-        if not self.agent_kv:
-            logger.error("KeyValueLoop not established. Exiting server loop.")
-            return
-
-        psub = await create_agent_consumer(self.js, self.id)
-
-        while not self._shutdown_event.is_set():
-            try:
-                msgs = await psub.fetch(1)
-                [self.create_task(msg.ack()) for msg in msgs]
-            except nats.errors.TimeoutError:
-                try:
-                    await psub.consumer_info()
-                except nats.js.errors.NotFoundError as e:
-                    self.agent_val.status = AgentStatus.ERROR
-                    _msg = f"Consumer not found: {e}"
-                    self.agent_val.add_error(_msg)
-                    logger.exception(_msg)
-                continue
-
-            for msg in msgs:
-                try:
-                    event = PipelineAssignment.model_validate_json(msg.data)
-                    assert event.agent_id == self.id
-                    logger.info(f"Agent ID verified: {event.agent_id}")
-                except (ValidationError, AssertionError) as e:
-                    self.agent_val.status = AgentStatus.ERROR
-                    _msg = f"Invalid assignment: {e}"
-                    self.agent_val.add_error(_msg)
-                    logger.exception(_msg)
-                    continue
-
-                try:
-                    valid_pipeline = PipelineJSON.model_validate(event.pipeline)
-                    self.pipeline = Pipeline.from_pipeline(valid_pipeline)
-                    self.my_operator_ids = event.operators_assigned
-                    self.agent_val.operator_assignments = (
-                        event.operators_assigned
-                    )  # Set operator assignments
-                    logger.info(f"Operators assigned: {self.my_operator_ids}")
-                    self.agent_val.status = AgentStatus.BUSY
-                    self.agent_val.status_message = "Starting operators..."
-                    await self.agent_kv.update_now()
-                    await self.start_operators()
-                    self.agent_val.status_message = "Operators started..."
-                    self.agent_val.status = AgentStatus.IDLE
-                    await self.agent_kv.update_now()
-                except Exception as e:
-                    self.agent_val.status = AgentStatus.ERROR
-                    _msg = f"Failed to start operators: {e}"
-                    self.agent_val.add_error(_msg)
-                    await self.agent_kv.update_now()
-                    publish_error(self.js, _msg, task_refs=self.task_refs)
-                    logger.exception(_msg)
-                    continue
-        logger.info("Server loop exiting")
-
-    async def setup_signal_handlers(self):
-        logger.info("Setting up signal handlers...")
-
-        loop = asyncio.get_running_loop()
-
-        def handle_signal(sig_num=None):
-            signal_name = (
-                signal.Signals(sig_num).name if sig_num is not None else "UNKNOWN"
-            )
-            logger.info(f"Signal {signal_name} received, shutting down processes...")
-            self._shutdown_event.set()
-
-        for sig in [signal.SIGINT, signal.SIGTERM]:
-            loop.add_signal_handler(sig, lambda s=sig: handle_signal(s))
-
-    async def start_operators(self) -> dict[uuid.UUID, Container]:
-        if not self.js:
-            raise ValueError("No JetStream context")
-        # Destroy any existing containers
-        await self.cancel_and_cleanup()
-        containers = {}
+    async def start_operators(self):
         if not self.pipeline:
-            logger.error("No pipeline configuration found...")
-            return containers
+            logger.info("No pipeline configuration found...")
+            return {}
 
         logger.info("Starting operators...")
 
         with PodmanClient(base_url=self._podman_service_uri) as client:
             tasks: list[asyncio.Task] = []
-
-            for id, op_info in self.pipeline.operators.items():
-                if id not in self.my_operator_ids:
+            for op_id, op_info in self.pipeline.operators.items():
+                if op_id not in self.my_operator_ids:
                     continue
-
-                task = self.create_task(
-                    self._start_operator(
-                        op_info,
-                        client,
-                    )
-                )
-                tasks.append(task)
+                # Create a task to start the operator
+                # and add it to the task list
+                tasks.append(self.create_task(self._start_operator(op_info, client)))
 
             results: list[
                 tuple[OperatorJSON, Container] | BaseException
@@ -360,15 +306,21 @@ class Agent:
                     _msg = f"Error starting operator: {result}"
                     logger.exception(_msg)
                     self.agent_val.add_error(_msg)
-                    publish_error(self.js, _msg, task_refs=self.task_refs)
+                    await self.error_publisher.publish(_msg)
                 else:
                     operator, container = result
-                    containers[operator.id] = container
-                    self.watch_tasks[operator.id] = self.create_task(
-                        self.container_task(operator, container)
+                    self.container_trackers[operator.id] = ContainerTracker(
+                        container, operator
                     )
-
-        return containers
+                    tracker = self.container_trackers[operator.id]
+                    if not operator.parameters:
+                        continue
+                    for param in operator.parameters:
+                        if not param.type == ParameterType.MOUNT:
+                            continue
+                        tracker.add_parameter_task(
+                            asyncio.create_task(self.parameter_task(tracker, param))
+                        )
 
     async def _start_operator(
         self, operator: OperatorJSON, client: PodmanClient
@@ -386,259 +338,144 @@ class Agent:
         env.update({OPERATOR_ID_ENV_VAR: str(operator.id)})
 
         # Mount in the operator credentials
-        operator.mounts.append(OPERATOR_CREDS_MOUNT)
+        if OPERATOR_CREDS_MOUNT not in operator.mounts:
+            operator.mounts.append(OPERATOR_CREDS_MOUNT)
         env.update(
             {"NATS_CREDS_FILE": OPERATOR_CREDS_TARGET, "NATS_SECURITY_MODE": "creds"}
         )
 
         if cfg.MOUNT_LOCAL_REPO:
-            operator.mounts.append(CORE_MOUNT)
-            operator.mounts.append(OPERATORS_MOUNT)
+            if CORE_MOUNT not in operator.mounts:
+                operator.mounts.append(CORE_MOUNT)
+            if OPERATORS_MOUNT not in operator.mounts:
+                operator.mounts.append(OPERATORS_MOUNT)
 
-        container = await create_container(
-            self.id,
-            client,
-            operator,
-            env,
-        )
+        container = await create_container(self.id, client, operator, env)
+        if not container:
+            raise RuntimeError(f"Failed to create container for operator {operator.id}")
         container.start()
 
-        if not self.js:
-            raise ValueError("No JetStream context")
-
         # Publish pipeline to JetStream
-        try:
-            await self.js.publish(
-                subject=f"{STREAM_OPERATORS}.{operator.id}",
-                payload=self.pipeline.to_json().model_dump_json().encode(),
-            )
-            logger.info(f"Published pipeline for operator {operator.id}")
-            logger.debug(f"Pipeline: {self.pipeline.to_json().model_dump_json()}")
-        except Exception as e:
-            raise ValueError(
-                f"Failed to publish to JetStream for operator {operator.id}: {e}"
-            )
+        await self.broker.publish(
+            subject=f"{STREAM_OPERATORS}.{operator.id}",
+            message=self.pipeline.to_json().model_dump_json(),
+        )
+        logger.info(f"Published pipeline for operator {operator.id}")
+        logger.debug(f"Pipeline: {self.pipeline.to_json().model_dump_json()}")
 
         return operator, container
 
-    async def container_task(
-        self, operator: OperatorJSON, container: Container
-    ) -> None:
-        """
-        Manages the operator's container lifecycle and restarts it when mount parameters change.
-        """
-        if not self.js:
-            raise ValueError("No JetStream context")
-
-        restart_event = asyncio.Event()
-
-        changed_parameters: dict[str, OperatorParameter] = {}
-        parameter_tasks: list[asyncio.Task] = []
-
-        current_operator = operator
-        current_container = container
-
-        # Start parameter tasks for each mount parameter
-        if operator.parameters is not None:
-            for param in operator.parameters:
-                if param.type != ParameterType.MOUNT:
-                    continue
-                changed_parameters[param.name] = param
-                # Start a parameter task for each mount parameter
-                parameter_task = self.create_task(
-                    self.parameter_task(
-                        current_operator, param, restart_event, changed_parameters
-                    )
-                )
-                parameter_tasks.append(parameter_task)
-
-        while not self._shutdown_event.is_set():
-            shutdown_task = self.create_task(self._shutdown_event.wait())
-            restart_task = self.create_task(restart_event.wait())
-
-            _, pending = await asyncio.wait(
-                [shutdown_task, restart_task],
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-
-            for task in pending:
-                task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
-
-            if self._shutdown_event.is_set():
-                break
-
-            # Check if the container is still running
-            try:
-                current_container.reload()
-            except podman.errors.exceptions.APIError as e:
-                logger.warning(f"Container {current_container.name} not found: {e}")
-                break
-            if current_container.status != "running":
-                logger.info(f"Container {current_container.name} is no longer running.")
-                await stop_and_remove_container(current_container)
-                break
-
-            if restart_event.is_set():
-                restart_event.clear()
-
-                # Restart the container with updated mounts
-                # No need to create a new operator; current_operator has updated mounts
-                # Re-resolve the mounts
-                resolved = True
-                for mount in current_operator.mounts:
-                    if not mount.resolve():
-                        _msg = f"Mount source not found: {mount.source}"
-                        logger.error(_msg)
-                        self.agent_val.add_error(_msg)
-                        resolved = False
-                if not resolved:
-                    logger.error("Failed to resolve mounts")
-                    continue
-
-                await stop_and_remove_container(current_container)
-                with PodmanClient(base_url=self._podman_service_uri) as client:
-                    try:
-                        new_operator, new_container = await self.create_task(
-                            self._start_operator(current_operator, client)
-                        )
-                        current_operator = new_operator
-                        current_container = new_container
-                    except Exception as e:
-                        _msg = f"Error starting operator: {e}"
-                        logger.exception(_msg)
-                        publish_error(self.js, _msg, task_refs=self.task_refs)
-                        self.agent_val.add_error(_msg)
-                        continue
-
-                for param in changed_parameters.values():
-                    await update_parameter(self.js, current_operator, param)
-                changed_parameters.clear()
-
-        for task in parameter_tasks:
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-
-        logger.info(f"Exited container task loop for operator {operator.id}")
-
     async def parameter_task(
-        self,
-        operator: OperatorJSON,
-        parameter: OperatorParameter,
-        restart_event: asyncio.Event,
-        changed_parameters: dict[str, OperatorParameter],
+        self, tracker: ContainerTracker, parameter: OperatorParameter
     ):
-        if not self.js:
-            raise ValueError("No JetStream context")
+        operator = tracker.operator
+        sub = self.broker.subscriber(
+            subject=f"{STREAM_PARAMETERS}.{operator.id}.{parameter.name}",
+            stream=STREAM_PARAMETERS,
+            description=f"agent-{self.id}-{operator.id}-{parameter.name}",
+            config=PARAMETER_CONSUMER_CONFIG,
+            pull_sub=True,
+        )
+        pub = self.broker.publisher(
+            stream=STREAM_PARAMETERS,
+            subject=f"{STREAM_PARAMETERS_UPDATE}.{operator.id}.{parameter.name}",
+        )
+        self.broker.setup_publisher(pub)
 
-        try:
-            psub = await create_agent_parameter_consumer(
-                self.js, self.id, operator, parameter
+        async def handler(msg: dict[str, Any]):
+            new_val = msg.get(parameter.name, "")
+            logger.info(
+                f"Received new value for parameter '{parameter.name}': {new_val}"
             )
-        except Exception as e:
-            logger.exception(f"Error subscribing to parameter {parameter.name}: {e}")
-            return
+            if new_val == parameter.value:
+                return
 
-        # Publish initial value
-        await update_parameter(self.js, operator, parameter)
+            # Validate the new value before updating
+            if not operator.validate_mount_for_parameter(parameter, new_val):
+                logger.error(
+                    f"Invalid mount path for parameter '{parameter.name}': {new_val}"
+                )
+                await self.error_publisher.publish("Path does not exist")
+                return
 
-        # Create an invalid parameter to publish when the parameter is invalid
-        invalid_parameter = OperatorParameter(
-            name=parameter.name,
-            label=parameter.label,
-            description=parameter.description,
-            type=parameter.type,
-            default=parameter.default,
-            required=parameter.required,
-            value="ERROR",
+            parameter.value = new_val
+            operator.update_mounts_for_parameter(parameter)
+
+            # Mark for a restart (handled in the monitor loop)
+            tracker.mark()
+            await pub.publish(json.dumps(new_val))
+
+        sub(handler)
+        self.broker.setup_subscriber(sub)
+
+        await sub.start()
+        logger.info(
+            f"Subscribed to parameter updates for {operator.id}.{parameter.name}"
         )
 
+        try:
+            while not self._shutdown_event.is_set():
+                await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            logger.info(f"Parameter task for {operator.id}.{parameter.name} cancelled.")
+            raise
+        finally:
+            await sub.close()
+            logger.info(
+                f"Closed parameter subscription for {operator.id}.{parameter.name}."
+            )
+
+    async def monitor_containers(self):
         while not self._shutdown_event.is_set():
-            try:
-                msgs = await psub.fetch(1, timeout=1)
-                if not msgs:
-                    continue
-                msg = msgs[0]
-                await msg.ack()
-                if not msg.data:
-                    logger.warning(
-                        f"Received empty message for parameter '{parameter.name}'"
-                    )
+            await asyncio.sleep(3)
+            for _, tracker in list(self.container_trackers.items()):
+                if tracker.marked_for_restart:
+                    await self.restart_operator(tracker)
+                    tracker.unmark()
                     continue
                 try:
-                    val = json.loads(msg.data.decode("utf-8"))
-                    new_val = val.get(parameter.name)
-                    if new_val == parameter.value:
-                        await update_parameter(self.js, operator, parameter)
-                        continue
-                    # Validate the new value before updating
-                    if not operator.validate_mount_for_parameter(parameter, new_val):
-                        logger.error(
-                            f"Invalid mount path for parameter '{parameter.name}': {new_val}"
+                    tracker.container.reload()
+                    if tracker.container.status != "running":
+                        logger.info(
+                            f"Container {tracker.container.name} stopped. Restarting..."
                         )
-                        await update_parameter(self.js, operator, invalid_parameter)
-                        continue
-
-                    parameter.value = new_val
-                    operator.update_mounts_for_parameter(parameter)
-                    changed_parameters[parameter.name] = parameter
-                    restart_event.set()
-                except json.JSONDecodeError as e:
-                    _msg = (
-                        f"Error decoding message for parameter '{parameter.name}': {e}"
+                        await self.restart_operator(tracker)
+                except podman.errors.exceptions.NotFound:
+                    logger.warning(
+                        f"Container {tracker.container.name} not found during monitoring"
                     )
-                    logger.exception(_msg)
-                    self.agent_val.add_error(_msg)
-                    publish_error(self.js, _msg, task_refs=self.task_refs)
-                    continue
-            except nats.errors.TimeoutError:
-                continue
-            except nats.js.errors.NotFoundError:
-                psub = await create_agent_parameter_consumer(
-                    self.js, self.id, operator, parameter
-                )
-                continue
-            except Exception as e:
-                _msg = f"Error fetching update for parameter '{parameter.name}': {e}"
-                logger.exception(_msg)
-                self.agent_val.add_error(_msg)
-                publish_error(self.js, _msg, task_refs=self.task_refs)
-                continue
+                    # Remove the tracker if the container is not found
+                    del self.container_trackers[tracker.operator.id]
+                except Exception as e:
+                    logger.exception(
+                        f"Error monitoring container {tracker.container.name}: {e}"
+                    )
 
-        await psub.unsubscribe()
-
-    async def cancel_and_cleanup(self):
-        for operator_id, task in self.watch_tasks.items():
-            logger.info(
-                f"Cancelling existing container task for operator {operator_id}"
-            )
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                logger.info(f"Container task for operator {operator_id} cancelled.")
-        self.watch_tasks.clear()
-        await self._cleanup_containers()
+    async def restart_operator(self, tracker: ContainerTracker):
+        container = tracker.container
+        operator = tracker.operator
+        logger.info(f"Restarting operator {tracker.operator.id}")
+        await stop_and_remove_container(container)
+        with PodmanClient(base_url=self._podman_service_uri) as client:
+            _, new_container = await self._start_operator(operator, client)
+            self.container_trackers[operator.id].container = new_container
 
     def create_task(self, coro: Coroutine) -> asyncio.Task:
         return create_task_with_ref(self.task_refs, coro)
 
 
-async def update_parameter(
-    js: JetStreamContext,
-    operator: OperatorJSON,
-    parameter: OperatorParameter,
-):
-    value = parameter.value if parameter.value is not None else parameter.default
-    subject = f"{STREAM_PARAMETERS_UPDATE}.{operator.id}.{parameter.name}"
-    payload = json.dumps(value).encode("utf-8")
-    asyncio.create_task(js.publish(subject=subject, payload=payload))
+class NameConflictError(podman.errors.exceptions.APIError):
+    pass
+
+
+def is_name_conflict_error(exc: Exception) -> bool:
+    if isinstance(exc, podman.errors.exceptions.APIError):
+        error_message = str(exc)
+        return (
+            "container name" in error_message and "is already in use" in error_message
+        )
+    else:
+        return False
 
 
 async def create_container(
@@ -646,7 +483,6 @@ async def create_container(
     client: PodmanClient,
     operator: OperatorJSON,
     env: dict[str, Any],
-    max_retries=1,
 ) -> Container:
     name = f"operator-{operator.id}"
     network_mode = operator.network_mode or "host"
@@ -668,12 +504,14 @@ async def create_container(
             logger.error(error_msg)
             raise RuntimeError(error_msg) from e
 
-    for attempt in range(max_retries + 1):
+    for attempt in stamina.retry_context(on=is_name_conflict_error):
         # Expand users
         # This should only be done at the agent (where data resides)
         for mount in operator.mounts:
             mount.resolve()
-        try:
+        with attempt:
+            if attempt.num > 1:
+                await handle_name_conflict(client, name)
             return client.containers.create(
                 image=operator.image,
                 environment=env,
@@ -688,39 +526,38 @@ async def create_container(
                 labels={"agent.id": str(agent_id)},
                 mounts=[mount.model_dump() for mount in operator.mounts],
             )
-        except podman.errors.exceptions.APIError as e:
-            # _cleanup_containers() doesn't work for dead containers
-            # These are left behind and need to be removed
-            # TODO: should _cleanup_containers() work for dead containers?
-            if is_name_conflict_error(e):
-                if attempt < max_retries:
-                    await handle_name_conflict(client, name)
-                else:
-                    raise e
-            else:
-                raise e
-        except Exception as e:
-            raise e
+
     raise RuntimeError(
-        f"Failed to create container {name} after {max_retries + 1} attempts"
+        f"Failed to create container for operator {operator.id} after multiple attempts"
     )
 
 
 async def stop_and_remove_container(container: Container) -> None:
+    class ContainerStillRunning(Exception):
+        pass
+
     try:
         container.reload()
+    except podman.errors.exceptions.NotFound:
+        logger.warning(f"Container {container.name} not found during reload")
+        return
+
+    try:
         if container.status == "running":
             logger.info(f"Stopping container {container.name}")
             await asyncio.to_thread(container.stop)
+            for attempt in stamina.retry_context(on=ContainerStillRunning):
+                with attempt:
+                    container.reload()
+                    if container.status == "running":
+                        raise ContainerStillRunning(
+                            f"Container {container.name} is still running"
+                        )
+
         logger.info(f"Removing container {container.name}")
-        await asyncio.to_thread(container.remove)
-    except podman.errors.exceptions.APIError as e:
-        logger.warning(f"Error stopping/removing container {container.name}: {e}")
-
-
-def is_name_conflict_error(error: podman.errors.exceptions.APIError) -> bool:
-    error_message = str(error)
-    return "container name" in error_message and "is already in use" in error_message
+        await asyncio.to_thread(container.remove, force=True)
+    except podman.errors.exceptions.NotFound:
+        logger.warning(f"Container {container.name} not found during removal")
 
 
 async def handle_name_conflict(client: PodmanClient, container_name: str) -> None:

--- a/backend/agent/interactem/agent/broker.py
+++ b/backend/agent/interactem/agent/broker.py
@@ -1,5 +1,3 @@
-from contextlib import asynccontextmanager
-
 from faststream import Context, ContextRepo, FastStream
 from faststream.nats import JStream, NatsBroker
 from nats.js.api import RetentionPolicy
@@ -47,11 +45,7 @@ logger = get_logger()
 AGENT_ID = cfg.ID
 broker = get_nats_broker(servers=[str(cfg.NATS_SERVER_URL)], name=f"agent-{AGENT_ID}")
 
-@asynccontextmanager
-async def lifespan(context: ContextRepo):
-    yield
-
-app = FastStream(broker=broker, lifespan=lifespan)
+app = FastStream(broker=broker)
 
 NOTIFICATIONS_JSTREAM = JStream(
     name=STREAM_NOTIFICATIONS,
@@ -88,6 +82,7 @@ AGENT_JSTREAM = JStream(
 
 agent_consumer_config = AGENT_CONSUMER_CONFIG
 agent_consumer_config.description = f"agent-{AGENT_ID}"
+
 
 @broker.subscriber(
     stream=AGENT_JSTREAM,

--- a/backend/agent/interactem/agent/broker.py
+++ b/backend/agent/interactem/agent/broker.py
@@ -1,0 +1,99 @@
+from contextlib import asynccontextmanager
+
+from faststream import Context, ContextRepo, FastStream
+from faststream.nats import JStream, NatsBroker
+from nats.js.api import RetentionPolicy
+
+from interactem.core.config import cfg as nats_cfg
+from interactem.core.constants import STREAM_AGENTS, STREAM_NOTIFICATIONS
+from interactem.core.logger import get_logger
+from interactem.core.models.pipeline import PipelineAssignment
+from interactem.core.nats.consumers import AGENT_CONSUMER_CONFIG
+
+from .agent import Agent, cfg
+
+
+def get_nats_broker(servers: list[str], name: str) -> NatsBroker:
+    options_map = {
+        nats_cfg.NATS_SECURITY_MODE.NKEYS: {
+            "nkeys_seed_str": nats_cfg.NKEYS_SEED_STR,
+        },
+        nats_cfg.NATS_SECURITY_MODE.CREDS: {
+            "user_credentials": str(nats_cfg.NATS_CREDS_FILE),
+        },
+    }
+    options = options_map[nats_cfg.NATS_SECURITY_MODE]
+
+    async def disconnected_cb():
+        logger.info("NATS disconnected.")
+
+    async def reconnected_cb():
+        logger.info("NATS reconnected.")
+
+    async def closed_cb():
+        logger.info("NATS connection closed.")
+
+    return NatsBroker(
+        servers=servers,
+        name=name,
+        reconnected_cb=reconnected_cb,
+        disconnected_cb=disconnected_cb,
+        closed_cb=closed_cb,
+        **options,
+    )
+
+
+logger = get_logger()
+AGENT_ID = cfg.ID
+broker = get_nats_broker(servers=[str(cfg.NATS_SERVER_URL)], name=f"agent-{AGENT_ID}")
+
+@asynccontextmanager
+async def lifespan(context: ContextRepo):
+    yield
+
+app = FastStream(broker=broker, lifespan=lifespan)
+
+NOTIFICATIONS_JSTREAM = JStream(
+    name=STREAM_NOTIFICATIONS,
+    description="A stream for notifications.",
+    subjects=[f"{STREAM_NOTIFICATIONS}.>"],
+    retention=RetentionPolicy.INTEREST,
+)
+
+error_pub = broker.publisher(
+    stream=NOTIFICATIONS_JSTREAM,
+    subject=f"{STREAM_NOTIFICATIONS}.errors",
+)
+
+
+@app.after_startup
+async def after_startup(context: ContextRepo, broker: NatsBroker = Context()):
+    agent = Agent(id=AGENT_ID, broker=broker)
+    agent.error_publisher = error_pub
+    context.set_global("agent", agent)
+    await agent.run()
+
+
+@app.on_shutdown
+async def on_shutdown(agent: Agent = Context()):
+    agent._shutdown_event.set()
+    await agent.shutdown()
+
+
+AGENT_JSTREAM = JStream(
+    name=STREAM_AGENTS,
+    description="A stream for messages to the agents.",
+    subjects=[f"{STREAM_AGENTS}.>"],
+)
+
+agent_consumer_config = AGENT_CONSUMER_CONFIG
+agent_consumer_config.description = f"agent-{AGENT_ID}"
+
+@broker.subscriber(
+    stream=AGENT_JSTREAM,
+    subject=f"{STREAM_AGENTS}.{AGENT_ID}",
+    config=agent_consumer_config,
+    pull_sub=True,
+)
+async def assignment_handler(assignment: PipelineAssignment, agent: Agent = Context()):
+    await agent.receive_assignment(assignment)

--- a/backend/agent/interactem/agent/broker.py
+++ b/backend/agent/interactem/agent/broker.py
@@ -70,7 +70,6 @@ async def after_startup(context: ContextRepo, broker: NatsBroker = Context()):
 
 @app.on_shutdown
 async def on_shutdown(agent: Agent = Context()):
-    agent._shutdown_event.set()
     await agent.shutdown()
 
 

--- a/backend/agent/interactem/agent/config.py
+++ b/backend/agent/interactem/agent/config.py
@@ -1,7 +1,8 @@
+import uuid
 from pathlib import Path
 
 import netifaces
-from pydantic import AnyWebsocketUrl, NatsDsn, model_validator
+from pydantic import AnyWebsocketUrl, Field, NatsDsn, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from interactem.core.logger import get_logger
@@ -11,6 +12,7 @@ logger = get_logger()
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+    ID: uuid.UUID = Field(default_factory=uuid.uuid4)
     LOCAL: bool = False
     DOCKER_COMPATIBILITY_MODE: bool = False
     PODMAN_SERVICE_URI: str | None = None

--- a/backend/agent/interactem/agent/entrypoint.py
+++ b/backend/agent/interactem/agent/entrypoint.py
@@ -1,12 +1,11 @@
 import asyncio
 
-from interactem.agent.agent import Agent, logger
+from interactem.agent.broker import app, logger
 
 
 async def main():
-    agent = Agent()
     try:
-        await agent.run()
+        await app.run()
     except KeyboardInterrupt:
         pass
     except Exception as e:

--- a/backend/agent/poetry.lock
+++ b/backend/agent/poetry.lock
@@ -144,6 +144,29 @@ files = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.9.0"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c"},
+    {file = "anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028"},
+]
+
+[package.dependencies]
+exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
+
+[package.extras]
+doc = ["Sphinx (>=8.2,<9.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
+test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "trustme", "truststore (>=0.9.1) ; python_version >= \"3.10\"", "uvloop (>=0.21) ; platform_python_implementation == \"CPython\" and platform_system != \"Windows\" and python_version < \"3.14\""]
+trio = ["trio (>=0.26.1)"]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 description = "Timeout context manager for asyncio programs"
@@ -417,6 +440,78 @@ humanfriendly = ">=9.1"
 cron = ["capturer (>=2.4)"]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.0"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "python_version < \"3.11\""
+files = [
+    {file = "exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10"},
+    {file = "exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
+name = "fast-depends"
+version = "2.4.12"
+description = "FastDepends - extracted and cleared from HTTP domain logic FastAPI Dependency Injection System. Async and sync are both supported."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "fast_depends-2.4.12-py3-none-any.whl", hash = "sha256:9e5d110ddc962329e46c9b35e5fe65655984247a13ee3ca5a33186db7d2d75c2"},
+    {file = "fast_depends-2.4.12.tar.gz", hash = "sha256:9393e6de827f7afa0141e54fa9553b737396aaf06bd0040e159d1f790487b16d"},
+]
+
+[package.dependencies]
+anyio = ">=3.0.0,<5.0.0"
+pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<3.0.0"
+
+[[package]]
+name = "faststream"
+version = "0.5.40"
+description = "FastStream: the simplest way to work with a messaging queues"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "faststream-0.5.40-py3-none-any.whl", hash = "sha256:abd153ceb77f9806d2cb7d384b0cecc826edfb3f569d21d04199bde50912e9dd"},
+    {file = "faststream-0.5.40.tar.gz", hash = "sha256:ad29ec54213858574fb17fabe9253aba6714696eb597e3a4ccc8bd816d14f25f"},
+]
+
+[package.dependencies]
+anyio = ">=3.7.1,<5"
+fast-depends = ">=2.4.0b0,<3.0.0"
+nats-py = {version = ">=2.7.0,<=3.0.0", optional = true, markers = "extra == \"nats\""}
+typer = {version = ">=0.9,<0.12 || >0.12,<=0.15.3", optional = true, markers = "extra == \"cli\""}
+typing-extensions = ">=4.8.0"
+watchfiles = {version = ">=0.15.0,<1.1.0", optional = true, markers = "extra == \"cli\""}
+
+[package.extras]
+cli = ["typer (>=0.9,!=0.12,<=0.15.3)", "watchfiles (>=0.15.0,<1.1.0)"]
+confluent = ["confluent-kafka (>=2,!=2.8.1,<3) ; python_version < \"3.13\"", "confluent-kafka (>=2.6,!=2.8.1,<3) ; python_version >= \"3.13\""]
+dev = ["aio-pika (>=9,<10)", "aiokafka (>=0.9,<0.13)", "bandit (==1.7.10) ; python_version < \"3.9\"", "bandit (==1.8.3) ; python_version >= \"3.9\"", "cairosvg", "codespell (==2.4.1)", "confluent-kafka (>=2,!=2.8.1,<3) ; python_version < \"3.13\"", "confluent-kafka (>=2.6,!=2.8.1,<3) ; python_version >= \"3.13\"", "confluent-kafka-stubs ; python_version >= \"3.11\"", "coverage[toml] (==7.6.1) ; python_version < \"3.9\"", "coverage[toml] (==7.8.0) ; python_version >= \"3.9\"", "detect-secrets (==1.5.0)", "dirty-equals (==0.9.0)", "email-validator (==2.2.0)", "fastapi (==0.115.12)", "httpx (==0.28.1)", "mdx-include (==1.4.2)", "mike (==2.1.3)", "mkdocs-git-revision-date-localized-plugin (==1.4.5)", "mkdocs-glightbox (==0.4.0)", "mkdocs-literate-nav (==0.6.2)", "mkdocs-macros-plugin (==1.3.7)", "mkdocs-material (==9.6.12)", "mkdocs-minify-plugin (==0.8.0)", "mkdocs-static-i18n (==1.3.0)", "mkdocstrings[python] (==0.26.1) ; python_version < \"3.9\"", "mkdocstrings[python] (==0.29.1) ; python_version >= \"3.9\"", "mypy (==1.15.0)", "nats-py (>=2.7.0,<=3.0.0)", "opentelemetry-sdk (>=1.24.0,<2.0.0)", "pillow", "pre-commit (==3.5.0) ; python_version < \"3.9\"", "pre-commit (==4.2.0) ; python_version >= \"3.9\"", "prometheus-client (>=0.20.0,<0.30.0)", "pydantic-settings (>=2.0.0,<3.0.0)", "pytest (==8.3.5)", "pytest-asyncio (==0.24.0) ; python_version < \"3.9\"", "pytest-asyncio (==0.26.0) ; python_version >= \"3.9\"", "pyyaml (==6.0.2)", "redis (>=5.0.0,<7.0.0)", "requests", "ruff (==0.11.8)", "semgrep (==1.120.1) ; python_version >= \"3.9\"", "semgrep (==1.99.0) ; python_version < \"3.9\"", "typer (>=0.9,!=0.12,<=0.15.3)", "types-aiofiles", "types-deprecated", "types-docutils", "types-pygments", "types-pyyaml", "types-redis", "types-setuptools", "types-ujson", "typing-extensions (>=4.8.0,<4.12.1) ; python_version < \"3.9\"", "watchfiles (>=0.15.0,<1.1.0)"]
+devdocs = ["cairosvg", "mdx-include (==1.4.2)", "mike (==2.1.3)", "mkdocs-git-revision-date-localized-plugin (==1.4.5)", "mkdocs-glightbox (==0.4.0)", "mkdocs-literate-nav (==0.6.2)", "mkdocs-macros-plugin (==1.3.7)", "mkdocs-material (==9.6.12)", "mkdocs-minify-plugin (==0.8.0)", "mkdocs-static-i18n (==1.3.0)", "mkdocstrings[python] (==0.26.1) ; python_version < \"3.9\"", "mkdocstrings[python] (==0.29.1) ; python_version >= \"3.9\"", "pillow", "requests"]
+kafka = ["aiokafka (>=0.9,<0.13)"]
+lint = ["aio-pika (>=9,<10)", "aiokafka (>=0.9,<0.13)", "bandit (==1.7.10) ; python_version < \"3.9\"", "bandit (==1.8.3) ; python_version >= \"3.9\"", "codespell (==2.4.1)", "confluent-kafka (>=2,!=2.8.1,<3) ; python_version < \"3.13\"", "confluent-kafka (>=2.6,!=2.8.1,<3) ; python_version >= \"3.13\"", "confluent-kafka-stubs ; python_version >= \"3.11\"", "mypy (==1.15.0)", "nats-py (>=2.7.0,<=3.0.0)", "opentelemetry-sdk (>=1.24.0,<2.0.0)", "prometheus-client (>=0.20.0,<0.30.0)", "redis (>=5.0.0,<7.0.0)", "ruff (==0.11.8)", "semgrep (==1.120.1) ; python_version >= \"3.9\"", "semgrep (==1.99.0) ; python_version < \"3.9\"", "typer (>=0.9,!=0.12,<=0.15.3)", "types-aiofiles", "types-deprecated", "types-docutils", "types-pygments", "types-pyyaml", "types-redis", "types-setuptools", "types-ujson", "watchfiles (>=0.15.0,<1.1.0)"]
+nats = ["nats-py (>=2.7.0,<=3.0.0)"]
+optionals = ["aio-pika (>=9,<10)", "aiokafka (>=0.9,<0.13)", "confluent-kafka (>=2,!=2.8.1,<3) ; python_version < \"3.13\"", "confluent-kafka (>=2.6,!=2.8.1,<3) ; python_version >= \"3.13\"", "nats-py (>=2.7.0,<=3.0.0)", "opentelemetry-sdk (>=1.24.0,<2.0.0)", "prometheus-client (>=0.20.0,<0.30.0)", "redis (>=5.0.0,<7.0.0)", "typer (>=0.9,!=0.12,<=0.15.3)", "watchfiles (>=0.15.0,<1.1.0)"]
+otel = ["opentelemetry-sdk (>=1.24.0,<2.0.0)"]
+prometheus = ["prometheus-client (>=0.20.0,<0.30.0)"]
+rabbit = ["aio-pika (>=9,<10)"]
+redis = ["redis (>=5.0.0,<7.0.0)"]
+test-core = ["coverage[toml] (==7.6.1) ; python_version < \"3.9\"", "coverage[toml] (==7.8.0) ; python_version >= \"3.9\"", "dirty-equals (==0.9.0)", "pytest (==8.3.5)", "pytest-asyncio (==0.24.0) ; python_version < \"3.9\"", "pytest-asyncio (==0.26.0) ; python_version >= \"3.9\"", "typing-extensions (>=4.8.0,<4.12.1) ; python_version < \"3.9\""]
+testing = ["coverage[toml] (==7.6.1) ; python_version < \"3.9\"", "coverage[toml] (==7.8.0) ; python_version >= \"3.9\"", "dirty-equals (==0.9.0)", "email-validator (==2.2.0)", "fastapi (==0.115.12)", "httpx (==0.28.1)", "pydantic-settings (>=2.0.0,<3.0.0)", "pytest (==8.3.5)", "pytest-asyncio (==0.24.0) ; python_version < \"3.9\"", "pytest-asyncio (==0.26.0) ; python_version >= \"3.9\"", "pyyaml (==6.0.2)", "typing-extensions (>=4.8.0,<4.12.1) ; python_version < \"3.9\""]
+types = ["aio-pika (>=9,<10)", "aiokafka (>=0.9,<0.13)", "confluent-kafka (>=2,!=2.8.1,<3) ; python_version < \"3.13\"", "confluent-kafka (>=2.6,!=2.8.1,<3) ; python_version >= \"3.13\"", "confluent-kafka-stubs ; python_version >= \"3.11\"", "mypy (==1.15.0)", "nats-py (>=2.7.0,<=3.0.0)", "opentelemetry-sdk (>=1.24.0,<2.0.0)", "prometheus-client (>=0.20.0,<0.30.0)", "redis (>=5.0.0,<7.0.0)", "typer (>=0.9,!=0.12,<=0.15.3)", "types-aiofiles", "types-deprecated", "types-docutils", "types-pygments", "types-pyyaml", "types-redis", "types-setuptools", "types-ujson", "watchfiles (>=0.15.0,<1.1.0)"]
+
+[[package]]
 name = "frozenlist"
 version = "1.5.0"
 description = "A list-like structure which implements collections.abc.MutableSequence"
@@ -569,6 +664,43 @@ tenacity = "^9.0.0"
 [package.source]
 type = "directory"
 url = "../core"
+
+[[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins"]
+profiling = ["gprof2dot"]
+rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
 
 [[package]]
 name = "multidict"
@@ -1093,6 +1225,21 @@ toml = ["tomli (>=2.0.1)"]
 yaml = ["pyyaml (>=6.0.1)"]
 
 [[package]]
+name = "pygments"
+version = "2.19.1"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"},
+    {file = "pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pynacl"
 version = "1.5.0"
 description = "Python binding to the Networking and Cryptography (NaCl) library"
@@ -1236,6 +1383,71 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "rich"
+version = "14.0.0"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.8.0"
+groups = ["main"]
+files = [
+    {file = "rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0"},
+    {file = "rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+description = "Tool to Detect Surrounding Shell"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
+    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+description = "Sniff out which async library your code is running under"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
+name = "stamina"
+version = "25.1.0"
+description = "Production-grade retries made easy."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "stamina-25.1.0-py3-none-any.whl", hash = "sha256:c08291da540e6f4243c20f7ee98f0ed0ac9101d639803c481a029b56d7e9b45d"},
+    {file = "stamina-25.1.0.tar.gz", hash = "sha256:ad674809796ae40512b3b6296cfade826efd63863ff2ca2f59f806342e91e94a"},
+]
+
+[package.dependencies]
+tenacity = "*"
+
+[package.extras]
+dev = ["anyio", "dirty-equals", "mypy (>=1.4)", "nox (>=2024.3.2)", "prometheus-client", "pytest", "structlog", "tomli ; python_version < \"3.11\"", "trio", "uv"]
+docs = ["furo", "myst-parser", "prometheus-client", "sphinx (>=7.2.2)", "sphinx-copybutton", "sphinx-notfound-page", "structlog"]
+tests = ["anyio", "dirty-equals", "pytest"]
+typing = ["mypy (>=1.4)"]
+
+[[package]]
 name = "tenacity"
 version = "9.0.0"
 description = "Retry code until it succeeds"
@@ -1307,6 +1519,24 @@ files = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.15.3"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "typer-0.15.3-py3-none-any.whl", hash = "sha256:c86a65ad77ca531f03de08d1b9cb67cd09ad02ddddf4b34745b5008f43b239bd"},
+    {file = "typer-0.15.3.tar.gz", hash = "sha256:818873625d0569653438316567861899f7e9972f2e6e0c16dab608345ced713c"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+rich = ">=10.11.0"
+shellingham = ">=1.3.0"
+typing-extensions = ">=3.7.4.3"
+
+[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -1335,6 +1565,90 @@ brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "b
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "watchfiles"
+version = "1.0.5"
+description = "Simple, modern and high performance file watching and code reload in python."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "watchfiles-1.0.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:5c40fe7dd9e5f81e0847b1ea64e1f5dd79dd61afbedb57759df06767ac719b40"},
+    {file = "watchfiles-1.0.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8c0db396e6003d99bb2d7232c957b5f0b5634bbd1b24e381a5afcc880f7373fb"},
+    {file = "watchfiles-1.0.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b551d4fb482fc57d852b4541f911ba28957d051c8776e79c3b4a51eb5e2a1b11"},
+    {file = "watchfiles-1.0.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:830aa432ba5c491d52a15b51526c29e4a4b92bf4f92253787f9726fe01519487"},
+    {file = "watchfiles-1.0.5-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a16512051a822a416b0d477d5f8c0e67b67c1a20d9acecb0aafa3aa4d6e7d256"},
+    {file = "watchfiles-1.0.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfe0cbc787770e52a96c6fda6726ace75be7f840cb327e1b08d7d54eadc3bc85"},
+    {file = "watchfiles-1.0.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d363152c5e16b29d66cbde8fa614f9e313e6f94a8204eaab268db52231fe5358"},
+    {file = "watchfiles-1.0.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ee32c9a9bee4d0b7bd7cbeb53cb185cf0b622ac761efaa2eba84006c3b3a614"},
+    {file = "watchfiles-1.0.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29c7fd632ccaf5517c16a5188e36f6612d6472ccf55382db6c7fe3fcccb7f59f"},
+    {file = "watchfiles-1.0.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8e637810586e6fe380c8bc1b3910accd7f1d3a9a7262c8a78d4c8fb3ba6a2b3d"},
+    {file = "watchfiles-1.0.5-cp310-cp310-win32.whl", hash = "sha256:cd47d063fbeabd4c6cae1d4bcaa38f0902f8dc5ed168072874ea11d0c7afc1ff"},
+    {file = "watchfiles-1.0.5-cp310-cp310-win_amd64.whl", hash = "sha256:86c0df05b47a79d80351cd179893f2f9c1b1cae49d96e8b3290c7f4bd0ca0a92"},
+    {file = "watchfiles-1.0.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:237f9be419e977a0f8f6b2e7b0475ababe78ff1ab06822df95d914a945eac827"},
+    {file = "watchfiles-1.0.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0da39ff917af8b27a4bdc5a97ac577552a38aac0d260a859c1517ea3dc1a7c4"},
+    {file = "watchfiles-1.0.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cfcb3952350e95603f232a7a15f6c5f86c5375e46f0bd4ae70d43e3e063c13d"},
+    {file = "watchfiles-1.0.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:68b2dddba7a4e6151384e252a5632efcaa9bc5d1c4b567f3cb621306b2ca9f63"},
+    {file = "watchfiles-1.0.5-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:95cf944fcfc394c5f9de794ce581914900f82ff1f855326f25ebcf24d5397418"},
+    {file = "watchfiles-1.0.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ecf6cd9f83d7c023b1aba15d13f705ca7b7d38675c121f3cc4a6e25bd0857ee9"},
+    {file = "watchfiles-1.0.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:852de68acd6212cd6d33edf21e6f9e56e5d98c6add46f48244bd479d97c967c6"},
+    {file = "watchfiles-1.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5730f3aa35e646103b53389d5bc77edfbf578ab6dab2e005142b5b80a35ef25"},
+    {file = "watchfiles-1.0.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:18b3bd29954bc4abeeb4e9d9cf0b30227f0f206c86657674f544cb032296acd5"},
+    {file = "watchfiles-1.0.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:ba5552a1b07c8edbf197055bc9d518b8f0d98a1c6a73a293bc0726dce068ed01"},
+    {file = "watchfiles-1.0.5-cp311-cp311-win32.whl", hash = "sha256:2f1fefb2e90e89959447bc0420fddd1e76f625784340d64a2f7d5983ef9ad246"},
+    {file = "watchfiles-1.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:b6e76ceb1dd18c8e29c73f47d41866972e891fc4cc7ba014f487def72c1cf096"},
+    {file = "watchfiles-1.0.5-cp311-cp311-win_arm64.whl", hash = "sha256:266710eb6fddc1f5e51843c70e3bebfb0f5e77cf4f27129278c70554104d19ed"},
+    {file = "watchfiles-1.0.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b5eb568c2aa6018e26da9e6c86f3ec3fd958cee7f0311b35c2630fa4217d17f2"},
+    {file = "watchfiles-1.0.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a04059f4923ce4e856b4b4e5e783a70f49d9663d22a4c3b3298165996d1377f"},
+    {file = "watchfiles-1.0.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e380c89983ce6e6fe2dd1e1921b9952fb4e6da882931abd1824c092ed495dec"},
+    {file = "watchfiles-1.0.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fe43139b2c0fdc4a14d4f8d5b5d967f7a2777fd3d38ecf5b1ec669b0d7e43c21"},
+    {file = "watchfiles-1.0.5-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee0822ce1b8a14fe5a066f93edd20aada932acfe348bede8aa2149f1a4489512"},
+    {file = "watchfiles-1.0.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a0dbcb1c2d8f2ab6e0a81c6699b236932bd264d4cef1ac475858d16c403de74d"},
+    {file = "watchfiles-1.0.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a2014a2b18ad3ca53b1f6c23f8cd94a18ce930c1837bd891262c182640eb40a6"},
+    {file = "watchfiles-1.0.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10f6ae86d5cb647bf58f9f655fcf577f713915a5d69057a0371bc257e2553234"},
+    {file = "watchfiles-1.0.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:1a7bac2bde1d661fb31f4d4e8e539e178774b76db3c2c17c4bb3e960a5de07a2"},
+    {file = "watchfiles-1.0.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ab626da2fc1ac277bbf752446470b367f84b50295264d2d313e28dc4405d663"},
+    {file = "watchfiles-1.0.5-cp312-cp312-win32.whl", hash = "sha256:9f4571a783914feda92018ef3901dab8caf5b029325b5fe4558c074582815249"},
+    {file = "watchfiles-1.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:360a398c3a19672cf93527f7e8d8b60d8275119c5d900f2e184d32483117a705"},
+    {file = "watchfiles-1.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:1a2902ede862969077b97523987c38db28abbe09fb19866e711485d9fbf0d417"},
+    {file = "watchfiles-1.0.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:0b289572c33a0deae62daa57e44a25b99b783e5f7aed81b314232b3d3c81a11d"},
+    {file = "watchfiles-1.0.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a056c2f692d65bf1e99c41045e3bdcaea3cb9e6b5a53dcaf60a5f3bd95fc9763"},
+    {file = "watchfiles-1.0.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9dca99744991fc9850d18015c4f0438865414e50069670f5f7eee08340d8b40"},
+    {file = "watchfiles-1.0.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:894342d61d355446d02cd3988a7326af344143eb33a2fd5d38482a92072d9563"},
+    {file = "watchfiles-1.0.5-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ab44e1580924d1ffd7b3938e02716d5ad190441965138b4aa1d1f31ea0877f04"},
+    {file = "watchfiles-1.0.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d6f9367b132078b2ceb8d066ff6c93a970a18c3029cea37bfd7b2d3dd2e5db8f"},
+    {file = "watchfiles-1.0.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f2e55a9b162e06e3f862fb61e399fe9f05d908d019d87bf5b496a04ef18a970a"},
+    {file = "watchfiles-1.0.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0125f91f70e0732a9f8ee01e49515c35d38ba48db507a50c5bdcad9503af5827"},
+    {file = "watchfiles-1.0.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:13bb21f8ba3248386337c9fa51c528868e6c34a707f729ab041c846d52a0c69a"},
+    {file = "watchfiles-1.0.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:839ebd0df4a18c5b3c1b890145b5a3f5f64063c2a0d02b13c76d78fe5de34936"},
+    {file = "watchfiles-1.0.5-cp313-cp313-win32.whl", hash = "sha256:4a8ec1e4e16e2d5bafc9ba82f7aaecfeec990ca7cd27e84fb6f191804ed2fcfc"},
+    {file = "watchfiles-1.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:f436601594f15bf406518af922a89dcaab416568edb6f65c4e5bbbad1ea45c11"},
+    {file = "watchfiles-1.0.5-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:2cfb371be97d4db374cba381b9f911dd35bb5f4c58faa7b8b7106c8853e5d225"},
+    {file = "watchfiles-1.0.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a3904d88955fda461ea2531fcf6ef73584ca921415d5cfa44457a225f4a42bc1"},
+    {file = "watchfiles-1.0.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2b7a21715fb12274a71d335cff6c71fe7f676b293d322722fe708a9ec81d91f5"},
+    {file = "watchfiles-1.0.5-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dfd6ae1c385ab481766b3c61c44aca2b3cd775f6f7c0fa93d979ddec853d29d5"},
+    {file = "watchfiles-1.0.5-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b659576b950865fdad31fa491d31d37cf78b27113a7671d39f919828587b429b"},
+    {file = "watchfiles-1.0.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1909e0a9cd95251b15bff4261de5dd7550885bd172e3536824bf1cf6b121e200"},
+    {file = "watchfiles-1.0.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:832ccc221927c860e7286c55c9b6ebcc0265d5e072f49c7f6456c7798d2b39aa"},
+    {file = "watchfiles-1.0.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85fbb6102b3296926d0c62cfc9347f6237fb9400aecd0ba6bbda94cae15f2b3b"},
+    {file = "watchfiles-1.0.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:15ac96dd567ad6c71c71f7b2c658cb22b7734901546cd50a475128ab557593ca"},
+    {file = "watchfiles-1.0.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4b6227351e11c57ae997d222e13f5b6f1f0700d84b8c52304e8675d33a808382"},
+    {file = "watchfiles-1.0.5-cp39-cp39-win32.whl", hash = "sha256:974866e0db748ebf1eccab17862bc0f0303807ed9cda465d1324625b81293a18"},
+    {file = "watchfiles-1.0.5-cp39-cp39-win_amd64.whl", hash = "sha256:9848b21ae152fe79c10dd0197304ada8f7b586d3ebc3f27f43c506e5a52a863c"},
+    {file = "watchfiles-1.0.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:f59b870db1f1ae5a9ac28245707d955c8721dd6565e7f411024fa374b5362d1d"},
+    {file = "watchfiles-1.0.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9475b0093767e1475095f2aeb1d219fb9664081d403d1dff81342df8cd707034"},
+    {file = "watchfiles-1.0.5-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc533aa50664ebd6c628b2f30591956519462f5d27f951ed03d6c82b2dfd9965"},
+    {file = "watchfiles-1.0.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fed1cd825158dcaae36acce7b2db33dcbfd12b30c34317a88b8ed80f0541cc57"},
+    {file = "watchfiles-1.0.5-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:554389562c29c2c182e3908b149095051f81d28c2fec79ad6c8997d7d63e0009"},
+    {file = "watchfiles-1.0.5-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:a74add8d7727e6404d5dc4dcd7fac65d4d82f95928bbee0cf5414c900e86773e"},
+    {file = "watchfiles-1.0.5-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb1489f25b051a89fae574505cc26360c8e95e227a9500182a7fe0afcc500ce0"},
+    {file = "watchfiles-1.0.5-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0901429650652d3f0da90bad42bdafc1f9143ff3605633c455c999a2d786cac"},
+    {file = "watchfiles-1.0.5.tar.gz", hash = "sha256:b7529b5dcc114679d43827d8c35a07c493ad6f083633d573d81c660abc5979e9"},
+]
+
+[package.dependencies]
+anyio = ">=3.0.0"
 
 [[package]]
 name = "yarl"
@@ -1436,4 +1750,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "49dedb83f9c2d736af29b7fac96688847c1c0b5116e522fd3f0c3667ebd54d75"
+content-hash = "857785b785cd69eabc9ea9a483521b938a8fa5ceb9176cd7af1cd6d7b610a28a"

--- a/backend/agent/pyproject.toml
+++ b/backend/agent/pyproject.toml
@@ -26,6 +26,8 @@ pydantic-settings = "^2.4"
 nkeys = "^0.2.1"
 aiohttp = "^3.11.12"
 netifaces2 = "^0.0.22"
+faststream = {version="^0.5.40", extras=["nats", "cli"]}
+stamina = "^25.1.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
There was a number of problems with the agent:

1. Restarts were not working well with mount parameter updates. 
2. We were getting consumer timeout errors because of multiple calls to `psub.fetch()`. The next time the fetch call came around, the pull subscription timed out (server-side), and the agent lost connection to nats. I initially tried to solve this by re-connecting, but this is error prone.
3. Multiple retry blocks...

I added faststream and stamina as dependencies to fix these things, and refactored for readability.

Here we will use the faststream cli to bring up the agent. This starts a broker/faststream app. The broker is used for the nats jetstream/connection inside the agent. The agent is also provided to the app in its context. 

We also have the ability to create dynamic subscribers (see parameter_task). There is a bug with this, but it will be fixed in a later release. I don't think it will impact us much right now. https://github.com/ag2ai/faststream/issues/2053 

I have not included faststream as a dependency to core. We can do this in the future if it makes sense.