### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,5 +1,7 @@
 name: Ruff
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/NERSC/interactEM/security/code-scanning/3](https://github.com/NERSC/interactEM/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only runs Ruff, which checks the codebase, it likely only requires `contents: read` permission. This change will explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum required for the workflow to function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
