### PR TITLE
fix: correct input path references in ParameterInfoTooltip

### DIFF
--- a/frontend/interactEM/src/components/nodes/parameterinfotooltip.tsx
+++ b/frontend/interactEM/src/components/nodes/parameterinfotooltip.tsx
@@ -1,7 +1,7 @@
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined"
 import { Box, IconButton, Paper, Tooltip, Typography } from "@mui/material"
 import type React from "react"
-import type { OperatorParameter } from "../client/generated/types.gen"
+import type { OperatorParameter } from "../../client/generated/types.gen"
 
 interface ParameterInfoTooltipProps {
   parameter: OperatorParameter


### PR DESCRIPTION
fix docker build due to incorrect input path references in ParameterInfoTooltip