### PR TITLE
Beam compensation operator -> Parallel and fix sparse frame converter

### DIFF
--- a/operators/beam-compensation/operator.json
+++ b/operators/beam-compensation/operator.json
@@ -37,5 +37,8 @@
       "options": ["plane", "interp"],
       "required": true
     }
-  ]
+  ],
+  "parallel_config": {
+    "type": "embarrassing"
+  }
 }

--- a/operators/sparse-frame-image-converter/Containerfile
+++ b/operators/sparse-frame-image-converter/Containerfile
@@ -1,5 +1,5 @@
-FROM ghcr.io/nersc/interactem/operator
+FROM ghcr.io/nersc/interactem/distiller-streaming
 
-RUN pip install numpy pillow matplotlib
+RUN pip install matplotlib
 
 COPY ./run.py /app/run.py

--- a/operators/sparse-frame-image-converter/run.py
+++ b/operators/sparse-frame-image-converter/run.py
@@ -3,24 +3,15 @@ from typing import Any
 
 import matplotlib.cm as cm
 import numpy as np
+from distiller_streaming.models import FrameHeader
 from PIL import Image, ImageEnhance
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 
 from interactem.core.logger import get_logger
 from interactem.core.models.messages import BytesMessage, MessageHeader, MessageSubject
 from interactem.operators.operator import operator
 
 logger = get_logger()
-
-
-class FrameHeader(BaseModel):
-    scan_number: int
-    frame_number: int | None = None
-    nSTEM_positions_per_row_m1: int
-    nSTEM_rows_m1: int
-    STEM_x_position_in_row: int
-    STEM_row_in_scan: int
-    modules: list[int]
 
 
 skip_counter = 0
@@ -50,7 +41,7 @@ def image_converter(
         logger.error("Invalid message")
         return None
 
-    frame_shape = (576, 576)
+    frame_shape = header.frame_shape
     data = np.frombuffer(inputs.data, dtype=np.uint32)
     y_indices, x_indices = np.unravel_index(data, frame_shape)
 


### PR DESCRIPTION
# Auto-generated...

This pull request updates the `sparse-frame-image-converter` operator and the `beam-compensation` operator configuration. The main changes involve updating the base image and dependencies for the container, refactoring the `FrameHeader` model to use a shared implementation, and making the frame shape dynamic based on the header. Additionally, a parallelization configuration is added to the `beam-compensation` operator.

**Refactoring and Dependency Updates:**

* Changed the base image in `Containerfile` to use `ghcr.io/nersc/interactem/distiller-streaming` and updated installed Python packages to only include `matplotlib`, removing `numpy` and `pillow` since they are likely provided by the new base image.
* Refactored `run.py` to import `FrameHeader` from `distiller_streaming.models` instead of defining it locally, ensuring consistency and reducing code duplication. [[1]](diffhunk://#diff-9059f2bbec8b8405ece0163ddd8eca2bfeb19dbfc869bab99313d400ec656ffaR6-R8) [[2]](diffhunk://#diff-9059f2bbec8b8405ece0163ddd8eca2bfeb19dbfc869bab99313d400ec656ffaL16-L25)

**Functionality Improvements:**

* Modified the `image_converter` function to use the dynamic `frame_shape` from the `FrameHeader` instead of a hardcoded value, improving flexibility for different input data shapes.

**Operator Configuration:**

* Added a `parallel_config` section with `"type": "embarrassing"` to the `beam-compensation/operator.json` file, likely to enable or specify parallel execution for the operator.