### PR TITLE
Add loading local operators

### DIFF
--- a/backend/app/interactem/app/core/config.py
+++ b/backend/app/interactem/app/core/config.py
@@ -118,6 +118,10 @@ class Settings(BaseSettings):
     CONTAINER_REGISTRY_NAMESPACE: str = "nersc"
     OPERATOR_CONTAINER_PREFIX: str = "interactem"
 
+    # Local operators - mount your local operators directory to make
+    # changes to operator specs locally
+    LOCAL_OPERATORS_DIR: Path = Path("/operators")
+
     # Internal API key
     ORCHESTRATOR_API_KEY: str = "changeme"
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,6 +10,7 @@ services:
       - ./backend/app/:/interactem/app
       - ./backend/core/:/interactem/core
       - ./backend/sfapi_models/:/interactem/sfapi_models
+      - ./operators/:/operators
     command: 
       - fastapi
       - run


### PR DESCRIPTION
we want to be able to change operators on the fly rather than going to ghcr.io first. this way we can change operator spec locally before pushing during development

# Generated:

This pull request introduces support for loading operator specifications from a local directory, making it easier to develop and test operators without publishing them to a container registry. The changes update both configuration and operator loading logic to merge local and registry-based operators, and ensure local operator directories are mounted in the development environment.

**Local operator loading and configuration:**

* Added a new `LOCAL_OPERATORS_DIR` configuration option in `config.py` to specify the directory for local operator specs.
* Updated `docker-compose.override.yml` to mount the local `./operators/` directory into the container at `/operators`, enabling local development of operators.

**Operator loading logic:**

* Modified `fetch_operators()` in `__init__.py` to load operator specs from the local directory if present, parse their `operator.json` files, and merge them with operators fetched from the container registry. Local operators override registry operators with the same ID. [[1]](diffhunk://#diff-8ddacc6143eb7f5f2ae2c431863db4ea52f3aea6f90bfbdf4d940c0711ddb4f7L67-R100) [[2]](diffhunk://#diff-8ddacc6143eb7f5f2ae2c431863db4ea52f3aea6f90bfbdf4d940c0711ddb4f7L88-R120)
* Updated type hints and imports to support the new logic and ensure operator specs are consistently represented as `OperatorSpec` objects.