### PR TITLE
Fixup operator remote push

### DIFF
--- a/operators/bake.sh
+++ b/operators/bake.sh
@@ -86,11 +86,15 @@ build_operators() {
     
     if [ -n "$TARGET" ]; then
         cmd+=("$TARGET")
-        cmd+=(--provenance=false)
     else
         cmd+=(operators)
     fi
 
+    cmd+=(--provenance=false)
+
+    # https://docs.docker.com/build/exporters/image-registry/
+    # https://docs.docker.com/reference/cli/docker/buildx/build/#output
+    cmd+=(--set "*.output=type=registry,oci-mediatypes=true")
     cmd+=(--file "$BAKE_FILE")
     cmd+=(--file "$VARS")
     
@@ -105,15 +109,12 @@ build_operators() {
             fi
         fi
     done
-    
+
     # Check if we found any labels
     if [ "$has_labels" = false ]; then
         echo "No operator.json files found or all are empty."
         return 1
     fi
-    
-    cmd+=(--push)
-    
 
     if $DRY_RUN; then
         cmd+=(--print)


### PR DESCRIPTION
when pushing the these before, the registry was not getting their manifests properly. exporting these with `OCI-mediatypes` true produces a good manifest. this will eventually be the default, see: https://github.com/moby/buildkit/issues/6171 and https://github.com/moby/buildkit/pull/6095

also add a `--dry-run` option

# Generated
This pull request adds a new `--dry-run` option to the `operators/bake.sh` script, allowing users to preview the Docker build commands without executing them. It also refactors how build arguments are assembled and ensures consistent use of provenance and registry output settings.

**New dry-run functionality:**

* Added a `DRY_RUN` flag and a `--dry-run` command-line option to the script, enabling users to print the build commands instead of running them. [[1]](diffhunk://#diff-b25617210d75c54f006fc5e57cebdbe4ce98302ea6b4a4983675b94c5c157d32R16) [[2]](diffhunk://#diff-b25617210d75c54f006fc5e57cebdbe4ce98302ea6b4a4983675b94c5c157d32R40-R43)
* Modified build command construction so that if `DRY_RUN` is enabled, the `--print` flag is included, causing Docker to output the build plan rather than execute it. [[1]](diffhunk://#diff-b25617210d75c54f006fc5e57cebdbe4ce98302ea6b4a4983675b94c5c157d32R65-R76) [[2]](diffhunk://#diff-b25617210d75c54f006fc5e57cebdbe4ce98302ea6b4a4983675b94c5c157d32L106-R121)

**Build command improvements:**

* Refactored the placement of the `--provenance=false` flag so it is always included, regardless of whether a specific target is set.
* Ensured that images are always pushed to the registry using OCI media types by adding `--set "*.output=type=registry,oci-mediatypes=true"` to the command.