### PR TITLE
don't send full message for metrics

### DIFF
--- a/backend/core/interactem/core/models/messages.py
+++ b/backend/core/interactem/core/models/messages.py
@@ -23,6 +23,16 @@ class OperatorTrackingMetadata(TrackingMetadataBase):
     time_before_operate: datetime
     time_after_operate: datetime
 
+class TrackingMetadatas(BaseModel):
+    metadatas: (
+        list[
+            OperatorTrackingMetadata
+            | OutputPortTrackingMetadata
+            | InputPortTrackingMetadata
+        ]
+        | None
+    ) = None
+
 
 class MessageSubject(str, Enum):
     BYTES = "bytes"
@@ -32,15 +42,7 @@ class MessageSubject(str, Enum):
 class MessageHeader(BaseModel):
     subject: MessageSubject
     meta: bytes | dict[str, Any] = b"{}"
-    tracking: (
-        list[
-            OperatorTrackingMetadata
-            | OutputPortTrackingMetadata
-            | InputPortTrackingMetadata
-        ]
-        | None
-    ) = None
-
+    tracking: TrackingMetadatas | None = None
 
 class BaseMessage(BaseModel):
     header: MessageHeader

--- a/backend/core/interactem/core/nats/publish.py
+++ b/backend/core/interactem/core/nats/publish.py
@@ -19,7 +19,7 @@ from ..constants import (
 )
 from ..models.base import IdType
 from ..models.messages import (
-    BytesMessage,
+    TrackingMetadatas,
 )
 from ..models.runtime import (
     PipelineAssignment,
@@ -32,13 +32,12 @@ from ..pipeline import Pipeline as PipelineGraph
 
 async def publish_pipeline_metrics(
     js: JetStreamContext,
-    msg: BytesMessage,
+    tracking: TrackingMetadatas,
 ):
-    """Used to send out the tracking information.
-    TODO: we may not want to publish the entire header here"""
+    """Used to send out the tracking information."""
     await js.publish(
         SUBJECT_PIPELINES_METRICS,
-        msg.header.model_dump_json().encode(),
+        tracking.model_dump_json().encode(),
         timeout=NATS_TIMEOUT_DEFAULT,
     )
 

--- a/backend/metrics/interactem/metrics/metrics.py
+++ b/backend/metrics/interactem/metrics/metrics.py
@@ -17,9 +17,9 @@ from interactem.core.logger import get_logger
 from interactem.core.models.kvs import PipelineRunVal
 from interactem.core.models.messages import (
     InputPortTrackingMetadata,
-    MessageHeader,
     OperatorTrackingMetadata,
     OutputPortTrackingMetadata,
+    TrackingMetadatas,
 )
 from interactem.core.models.metrics import OperatorMetrics, PortMetrics
 from interactem.core.models.runtime import RuntimePipeline
@@ -152,8 +152,8 @@ async def metrics_watch(js: JetStreamContext, update_interval: int):
         await asyncio.sleep(update_interval)
 
 
-def log_comparison(header: MessageHeader, pipeline: RuntimePipeline):
-    tracking = header.tracking
+def log_comparison(header: TrackingMetadatas, pipeline: RuntimePipeline):
+    tracking = header.metadatas
     if not tracking:
         logger.warning("No tracking information found...")
         return
@@ -237,7 +237,7 @@ async def handle_metrics(msg: NATSMsg, js: JetStreamContext):
 
     valid_pipeline = pipeline.pipeline
 
-    data = MessageHeader.model_validate_json(msg.data.decode("utf-8"))
+    data = TrackingMetadatas.model_validate_json(msg.data.decode("utf-8"))
     try:
         log_comparison(data, valid_pipeline)
     except networkx.exception.NetworkXError as e:


### PR DESCRIPTION
- this was resulting in errors where we couldn’t 
  Json-dump bytes in the metadata of messages.
- We move the tracking list into its own class to 
  avoid this.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #249 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #250 
<!-- GitButler Footer Boundary Bottom -->

