### PR TITLE
[#274] fix for when config could be null

### DIFF
--- a/frontend/interactEM/src/hooks/nats/useConsumer.ts
+++ b/frontend/interactEM/src/hooks/nats/useConsumer.ts
@@ -10,7 +10,7 @@ import { useNats } from "../../contexts/nats"
 
 interface UseConsumerOptions {
   stream: string
-  config: ConsumerConfig
+  config: ConsumerConfig | null
 }
 
 export const useConsumer = ({
@@ -26,6 +26,21 @@ export const useConsumer = ({
   useEffect(() => {
     // Mark component as mounted when effect runs
     isMounted.current = true
+
+    // If config is null, clear the consumer
+    if (!config) {
+      const consumerToDelete = consumerRef.current
+      if (consumerToDelete) {
+        consumerToDelete.delete().catch((error) => {
+          if (!(error instanceof DrainingConnectionError)) {
+            console.error("Error deleting consumer:", error)
+          }
+        })
+        consumerRef.current = null
+      }
+      setConsumer(null)
+      return
+    }
 
     const deleteConsumer = async (consumerToDelete: Consumer | null) => {
       if (!consumerToDelete) return

--- a/frontend/interactEM/src/hooks/nats/useOperatorLogs.ts
+++ b/frontend/interactEM/src/hooks/nats/useOperatorLogs.ts
@@ -63,7 +63,7 @@ export function useOperatorLogs({
     }
   }, [deploymentIdOrActiveId, sortedOperatorIds])
 
-  const consumer = config ? useConsumer({ stream: STREAM_LOGS, config }) : null
+  const consumer = useConsumer({ stream: STREAM_LOGS, config })
 
   const handleMessage = useCallback((msg: any) => {
     try {


### PR DESCRIPTION
- Guard against a null config to prevent runtime errors
- null check before accessing values

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #277 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #276 
<!-- GitButler Footer Boundary Bottom -->

