### PR TITLE
use minimal NATS stream storage config

### DIFF
--- a/backend/agent/interactem/agent/broker.py
+++ b/backend/agent/interactem/agent/broker.py
@@ -7,9 +7,9 @@ from interactem.core.constants import NATS_TIMEOUT_DEFAULT, SUBJECT_AGENTS_DEPLO
 from interactem.core.logger import get_logger
 from interactem.core.models.runtime import PipelineAssignment
 from interactem.core.nats.broker import get_nats_broker
-from interactem.core.nats.config import DEPLOYMENTS_JSTREAM
 from interactem.core.nats.consumers import AGENT_CONSUMER_CONFIG
 from interactem.core.nats.publish import create_agent_error_publisher
+from interactem.core.nats.streams import DEPLOYMENTS_JSTREAM
 
 from .agent import Agent, cfg
 

--- a/backend/app/interactem/app/events/consumer.py
+++ b/backend/app/interactem/app/events/consumer.py
@@ -2,8 +2,8 @@ from interactem.core.constants import SUBJECT_PIPELINES_DEPLOYMENTS_UPDATE
 from interactem.core.events.pipelines import PipelineUpdateEvent
 from interactem.core.logger import get_logger
 from interactem.core.nats.broker import get_nats_broker
-from interactem.core.nats.config import DEPLOYMENTS_JSTREAM
 from interactem.core.nats.consumers import PIPELINE_UPDATE_CONSUMER_CONFIG
+from interactem.core.nats.streams import DEPLOYMENTS_JSTREAM
 
 from ..api.faststream_deps import OrchestratorApiKeyDep, SessionDep
 from ..api.routes.deployments import _handle_update_pipeline_state

--- a/backend/callout/test/run.py
+++ b/backend/callout/test/run.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from core.nats import create_or_update_stream, nc
-from core.nats.config import AGENTS_STREAM_CONFIG
+from core.nats.streams import AGENTS_STREAM_CONFIG
 from nats.aio.client import Client as NATSClient
 from pydantic_settings import BaseSettings, SettingsConfigDict
 

--- a/backend/core/interactem/core/config.py
+++ b/backend/core/interactem/core/config.py
@@ -1,8 +1,6 @@
 import pathlib
 from enum import Enum
 
-from nats.js.api import StorageType
-from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -13,10 +11,6 @@ class LogLevel(str, Enum):
     ERROR = "ERROR"
     CRITICAL = "CRITICAL"
 
-class NatsMode(str, Enum):
-    NKEYS = "nkeys"
-    CREDS = "creds"
-
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
@@ -25,56 +19,6 @@ class Settings(BaseSettings):
         pathlib.Path(__file__).parent.parent.parent.parent / "operators" / "interactem"
     )
     LOG_LEVEL: LogLevel = LogLevel.INFO
-
-    # ------- NATS settings -------
-    NATS_SECURITY_MODE: NatsMode = NatsMode.CREDS
-    # We need to supply either the NKEY seed string or file for all clients
-    NKEYS_SEED_STR: str = ""
-    NKEYS_SEED_FILE: pathlib.Path | None = None
-
-    # If creds mode, we need to supply the creds file
-    NATS_CREDS_FILE: pathlib.Path | None = None
-    NATS_STREAM_STORAGE_TYPE: StorageType = StorageType.MEMORY
-
-    @model_validator(mode="after")
-    def validate_nats(self) -> "Settings":
-        mode_method_map = {
-            NatsMode.NKEYS: self.validate_nkeys,
-            NatsMode.CREDS: self.validate_creds,
-        }
-        return mode_method_map[self.NATS_SECURITY_MODE]()
-
-    def validate_nkeys(self) -> "Settings":
-        if not self.NKEYS_SEED_FILE and not self.NKEYS_SEED_STR:
-            raise ValueError(
-                "Either NKEYS_SEED_FILE or NKEYS_SEED_STR must be provided"
-            )
-        if self.NKEYS_SEED_FILE and self.NKEYS_SEED_STR:
-            raise ValueError(
-                "Only one of NKEYS_SEED_FILE or NKEYS_SEED_STR must be provided"
-            )
-
-        # We only use NKEYS_SEED_STR in the rest of code
-        if self.NKEYS_SEED_FILE:
-            if not self.NKEYS_SEED_FILE.is_file():
-                raise ValueError(f"File not found: {self.NKEYS_SEED_FILE}")
-
-            with open(self.NKEYS_SEED_FILE) as f:
-                self.NKEYS_SEED_STR = f.readline().strip()
-
-        if not self.NKEYS_SEED_STR:
-            raise ValueError("NKEYS_SEED_STR must not be empty")
-
-        return self
-
-    def validate_creds(self) -> "Settings":
-        if not self.NATS_CREDS_FILE:
-            raise ValueError("NATS_CREDS_FILE must be provided")
-        if not self.NATS_CREDS_FILE.exists() or not self.NATS_CREDS_FILE.is_file():
-            raise ValueError(f"NATS creds file not found: {self.NATS_CREDS_FILE}")
-
-        self.NATS_CREDS_FILE = self.NATS_CREDS_FILE.expanduser().resolve()
-        return self
 
 
 cfg = Settings()

--- a/backend/core/interactem/core/nats/broker.py
+++ b/backend/core/interactem/core/nats/broker.py
@@ -1,20 +1,22 @@
 from faststream.nats import NatsBroker
 
-from interactem.core.config import cfg
 from interactem.core.logger import get_logger
+
+from .config import NatsMode, get_nats_config
 
 logger = get_logger()
 
 def get_nats_broker(servers: list[str], name: str) -> NatsBroker:
+    nats_cfg = get_nats_config()
     options_map = {
-        cfg.NATS_SECURITY_MODE.NKEYS: {
-            "nkeys_seed_str": cfg.NKEYS_SEED_STR,
+        NatsMode.NKEYS: {
+            "nkeys_seed_str": nats_cfg.NKEYS_SEED_STR,
         },
-        cfg.NATS_SECURITY_MODE.CREDS: {
-            "user_credentials": str(cfg.NATS_CREDS_FILE),
+        NatsMode.CREDS: {
+            "user_credentials": str(nats_cfg.NATS_CREDS_FILE),
         },
     }
-    options = options_map[cfg.NATS_SECURITY_MODE]
+    options = options_map[nats_cfg.NATS_SECURITY_MODE]
 
     async def disconnected_cb():
         logger.info("NATS disconnected.")

--- a/backend/core/interactem/core/nats/publish.py
+++ b/backend/core/interactem/core/nats/publish.py
@@ -26,7 +26,7 @@ from ..models.runtime import (
     RuntimeOperatorID,
     RuntimeOperatorParameterAck,
 )
-from ..nats.config import NOTIFICATIONS_JSTREAM
+from ..nats.streams import NOTIFICATIONS_JSTREAM
 from ..pipeline import Pipeline as PipelineGraph
 
 

--- a/backend/core/interactem/core/nats/storage.py
+++ b/backend/core/interactem/core/nats/storage.py
@@ -1,0 +1,17 @@
+"""NATS stream storage type configuration.
+
+This is separated from the main NATS config to allow stream configs to be defined
+without triggering full NATS credential validation.
+"""
+
+from nats.js.api import StorageType
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class StorageConfig(BaseSettings):
+    """Minimal config for just the stream storage type."""
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+    NATS_STREAM_STORAGE_TYPE: StorageType = StorageType.MEMORY
+
+cfg = StorageConfig()

--- a/backend/core/interactem/core/nats/streams.py
+++ b/backend/core/interactem/core/nats/streams.py
@@ -1,0 +1,107 @@
+"""Stream configuration definitions for NATS JetStream."""
+
+from faststream.nats import JStream
+from nats.js.api import RetentionPolicy, StreamConfig
+
+from interactem.core.constants import (
+    MAX_LOGS_PER_SUBJECT,
+    STREAM_DEPLOYMENTS,
+    STREAM_IMAGES,
+    STREAM_LOGS,
+    STREAM_METRICS,
+    STREAM_NOTIFICATIONS,
+    STREAM_PARAMETERS,
+    STREAM_SFAPI,
+    STREAM_TABLES,
+    SUBJECT_DEPLOYMENTS_ALL,
+    SUBJECT_IMAGES_ALL,
+    SUBJECT_LOGS_ALL,
+    SUBJECT_NOTIFICATIONS_ALL,
+    SUBJECT_PARAMETERS_ALL,
+    SUBJECT_SFAPI_ALL,
+    SUBJECT_TABLES_ALL,
+)
+
+from .storage import cfg
+
+_storage = cfg.NATS_STREAM_STORAGE_TYPE
+
+PARAMETERS_STREAM_CONFIG = StreamConfig(
+    name=STREAM_PARAMETERS,
+    description="A stream for operator parameters.",
+    subjects=[SUBJECT_PARAMETERS_ALL],
+    max_msgs_per_subject=1,
+    storage=_storage,
+)
+
+IMAGES_STREAM_CONFIG = StreamConfig(
+    name=STREAM_IMAGES,
+    description="A stream for images.",
+    subjects=[SUBJECT_IMAGES_ALL],
+    max_msgs_per_subject=1,
+    storage=_storage,
+)
+
+METRICS_STREAM_CONFIG = StreamConfig(
+    name=STREAM_METRICS,
+    description="A stream for message metrics.",
+    subjects=[f"{STREAM_METRICS}.>"],
+    max_age=60,
+    storage=_storage,
+)
+
+SFAPI_STREAM_CONFIG = StreamConfig(
+    name=STREAM_SFAPI,
+    description="A stream for messages to the SFAPI.",
+    subjects=[SUBJECT_SFAPI_ALL],
+    storage=_storage,
+)
+
+NOTIFICATIONS_STREAM_CONFIG = StreamConfig(
+    name=STREAM_NOTIFICATIONS,
+    description="A stream for notifications.",
+    subjects=[SUBJECT_NOTIFICATIONS_ALL],
+    retention=RetentionPolicy.INTEREST,
+    storage=_storage,
+)
+
+NOTIFICATIONS_JSTREAM = JStream(
+    name=STREAM_NOTIFICATIONS,
+    description="A stream for notifications.",
+    subjects=[SUBJECT_NOTIFICATIONS_ALL],
+    retention=RetentionPolicy.INTEREST,
+    storage=_storage,
+)
+
+DEPLOYMENTS_STREAM_CONFIG = StreamConfig(
+    name=STREAM_DEPLOYMENTS,
+    description="A stream for deployments.",
+    subjects=[SUBJECT_DEPLOYMENTS_ALL],
+    storage=_storage,
+)
+
+DEPLOYMENTS_JSTREAM = JStream(
+    name=STREAM_DEPLOYMENTS,
+    description="A stream for deployments.",
+    subjects=[SUBJECT_DEPLOYMENTS_ALL],
+    storage=_storage,
+)
+
+TABLE_STREAM_CONFIG = StreamConfig(
+    name=STREAM_TABLES,
+    subjects=[SUBJECT_TABLES_ALL],
+    description="A stream for tables.",
+    retention=RetentionPolicy.LIMITS,
+    max_msgs_per_subject=1,
+    storage=_storage,
+)
+
+LOGS_STREAM_CONFIG = StreamConfig(
+    name=STREAM_LOGS,
+    subjects=[SUBJECT_LOGS_ALL],
+    description="A stream for logs.",
+    retention=RetentionPolicy.LIMITS,
+    max_msgs_per_subject=MAX_LOGS_PER_SUBJECT,
+    max_age=3600 * 24 * 7,
+    storage=_storage,
+)


### PR DESCRIPTION
Introduce a dedicated StorageConfig to hold the NATS stream storage
type and move stream-only settings out of the main Settings. Add a
small storage-only module (nats/storage.py) so stream configs can be
defined without needing NATS credentials.

Remove NATS mode/credential validation and related fields from
the global config to decouple stream configuration from client
authentication. Update nats/config.py to rely on the separate storage
setting (preparing for simplified stream definitions and avoiding
side effects of credential checks on import).

closes #261 