### PR TITLE
#249 fixup

### DIFF
--- a/backend/core/interactem/core/models/messages.py
+++ b/backend/core/interactem/core/models/messages.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from interactem.core.models.base import IdType
 
@@ -24,14 +24,11 @@ class OperatorTrackingMetadata(TrackingMetadataBase):
     time_after_operate: datetime
 
 class TrackingMetadatas(BaseModel):
-    metadatas: (
-        list[
-            OperatorTrackingMetadata
-            | OutputPortTrackingMetadata
-            | InputPortTrackingMetadata
-        ]
-        | None
-    ) = None
+    metadatas: list[
+        OperatorTrackingMetadata
+        | OutputPortTrackingMetadata
+        | InputPortTrackingMetadata
+    ] = Field(default_factory=list)
 
 
 class MessageSubject(str, Enum):

--- a/backend/operators/interactem/operators/messengers/zmq.py
+++ b/backend/operators/interactem/operators/messengers/zmq.py
@@ -139,7 +139,7 @@ class ZmqMessenger(BaseMessenger):
 
             # Tracking update
             if header.tracking is not None:
-                header.tracking.append(
+                header.tracking.metadatas.append(
                     InputPortTrackingMetadata(
                         id=id, time_after_header_validate=datetime.now()
                     )
@@ -179,7 +179,7 @@ class ZmqMessenger(BaseMessenger):
                 meta = OutputPortTrackingMetadata(
                     id=socket.info.port_id, time_before_send=time_before_send
                 )
-                header.tracking.append(meta)
+                header.tracking.metadatas.append(meta)
 
             # --- Separate meta if it's bytes ---
             raw_meta = None

--- a/backend/operators/interactem/operators/operator.py
+++ b/backend/operators/interactem/operators/operator.py
@@ -533,9 +533,8 @@ class OperatorMixin(RunnableKernel):
             time_after_operate=after_kernel,
         )
         if msg.header.tracking is None:
-            msg.header.tracking = TrackingMetadatas(metadatas=[])
-        if msg.header.tracking.metadatas:
-            msg.header.tracking.metadatas.append(meta)
+            msg.header.tracking = TrackingMetadatas()
+        msg.header.tracking.metadatas.append(meta)
         return msg
 
     async def _update_and_publish_pipeline_metrics(


### PR DESCRIPTION
failed to add append to metadatas in messenger, blocking sending 
messages.

we also make TrackingMetadata.metadatas non-optional so we don’t have to
defensively check every time if metadatas also exist