### PR TITLE
fix bucket creation to enable PURGE events to be sent to KV watchers

### DIFF
--- a/backend/core/interactem/core/nats/__init__.py
+++ b/backend/core/interactem/core/nats/__init__.py
@@ -178,7 +178,8 @@ async def consume_messages(
     handler: Callable[[NATSMsg, JetStreamContext], Awaitable],
     js: JetStreamContext,
     num_msgs: int = 1,
-    create_consumer: Callable[[], Awaitable[JetStreamContext.PullSubscription]] | None = None,
+    create_consumer: Callable[[], Awaitable[JetStreamContext.PullSubscription]]
+    | None = None,
 ):
     logger.info(f"Consuming messages on pull subscription {await psub.consumer_info()}")
     handler_tasks: set[asyncio.Task] = set()
@@ -252,6 +253,7 @@ async def create_or_update_stream(
 
     return stream_info
 
+
 async def create_all_streams(js: JetStreamContext) -> list[StreamInfo]:
     stream_infos: list[StreamInfo] = []
     tasks: set[asyncio.Task] = set()
@@ -294,6 +296,7 @@ async def create_all_streams(js: JetStreamContext) -> list[StreamInfo]:
         logger.error(f"Failed to create or update streams: {e}")
         raise
     return stream_infos
+
 
 async def create_all_buckets(js: JetStreamContext) -> list[KeyValue]:
     bucket_infos: list[KeyValue] = []


### PR DESCRIPTION
Currently the nats python client doesn’t allow us to create/update a bucket where events from TTL purges are sent to consumers. Without this, we cannot react to something dying on the backend (e.g., an agent or operator).

This will be a future TODO when new version of nats.py is out (coming soon?).

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #294 
- <kbd>&nbsp;1&nbsp;</kbd> #293 👈 
<!-- GitButler Footer Boundary Bottom -->

