### PR TITLE
don't create/update stream in operator

### DIFF
--- a/operators/image-display/run.py
+++ b/operators/image-display/run.py
@@ -3,8 +3,6 @@ from typing import Any
 
 from interactem.core.logger import get_logger
 from interactem.core.models.messages import BytesMessage
-from interactem.core.nats import create_or_update_stream
-from interactem.core.nats.config import IMAGES_STREAM_CONFIG
 from interactem.core.nats.publish import publish_image
 from interactem.operators.operator import AsyncOperator
 
@@ -18,17 +16,7 @@ class ImageDisplay(AsyncOperator):
 
         self.image_stream = None
 
-    # TODO Would be nice to be able todo this is a custom
-    # start method, but that is currently not possible as
-    # the start method doesn't return.
-    async def _ensure_stream(self):
-        if not self.image_stream:
-            self.image_stream = await create_or_update_stream(
-                IMAGES_STREAM_CONFIG, self.js
-            )
-
     async def _publish_image(self, image_data: bytes):
-        await self._ensure_stream()
 
         # We publish this on the canonical operator ID,
         # TODO: may need to adjust the way we are handling this

--- a/operators/table-display/run.py
+++ b/operators/table-display/run.py
@@ -4,8 +4,6 @@ from typing import Any
 
 from interactem.core.logger import get_logger
 from interactem.core.models.messages import BytesMessage
-from interactem.core.nats import create_or_update_stream
-from interactem.core.nats.config import TABLE_STREAM_CONFIG
 from interactem.core.nats.publish import publish_table_data
 from interactem.operators.operator import AsyncOperator
 
@@ -22,17 +20,7 @@ class TableDisplay(AsyncOperator):
         super().__init__()
         self.table_stream = None
 
-    async def _ensure_stream(self):
-        if not self.table_stream:
-            logger.info(f"Ensuring NATS stream '{TABLE_STREAM_CONFIG.name}' exists...")
-            self.table_stream = await create_or_update_stream(
-                TABLE_STREAM_CONFIG, self.js
-            )
-            logger.info(f"NATS stream '{TABLE_STREAM_CONFIG.name}' ensured.")
-
     async def _publish_table_data(self, table_data_json: bytes):
-        await self._ensure_stream()
-
         await publish_table_data(
             self.js,
             table_data_json=table_data_json,


### PR DESCRIPTION
We don’t need to do this, as this is managed in the FastAPI.

Since everything initializes there (and that service needs to be 
running for anything to work), I don’t think we need this “ensure 
stream” call.