### PR TITLE
Validate TCP connect port for ZMQ addresses

### DIFF
--- a/backend/core/interactem/core/models/uri.py
+++ b/backend/core/interactem/core/models/uri.py
@@ -120,6 +120,8 @@ class ZMQAddress(BaseModel):
         if self.protocol == Protocol.tcp:
             if not self.hostname:
                 raise ValueError("Hostname must be set for connecting.")
+            if not self.port:
+                raise ValueError("Port must be set for TCP connections.")
             return f"{self.protocol.value}://{self.hostname}:{self.port}"
         elif self.protocol in [Protocol.inproc, Protocol.ipc]:
             return f"{self.protocol.value}://{self.endpoint}"

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -53,6 +53,18 @@ def test_zmqaddress_tcp():
     assert address.to_connect_address() == "tcp://12.123.45.123:1234"
 
 
+def test_zmqaddress_tcp_missing_port_from_address():
+    address = ZMQAddress.from_address("tcp://?hostname=12.123.45.123")
+    with pytest.raises(ValueError, match="Port must be set for TCP connections."):
+        address.to_connect_address()
+
+
+def test_zmqaddress_tcp_missing_port_from_model():
+    address = ZMQAddress(protocol=Protocol.tcp, hostname="12.123.45.123")
+    with pytest.raises(ValueError, match="Port must be set for TCP connections."):
+        address.to_connect_address()
+
+
 def test_zmqaddress_tcp_with_interface():
     address = ZMQAddress.from_address("tcp://?interface=eth0&port=1234")
     assert address.protocol == Protocol.tcp


### PR DESCRIPTION
## Summary
- ensure ZMQ TCP connect addresses require a port before rendering
- add test coverage for TCP addresses missing ports to validate new guard

## Testing
- pytest tests/test_uri.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f5da163f0832aba5948e4f3e8139f)