### PR TITLE
Fix ParallelType embarrassing spelling

### DIFF
--- a/backend/core/interactem/core/models/spec.py
+++ b/backend/core/interactem/core/models/spec.py
@@ -108,7 +108,7 @@ class OperatorSpecTag(BaseModel):
 
 class ParallelType(str, Enum):
     NONE = "none"
-    EMBARASSING = "embarrassing"
+    EMBARRASSING = "embarrassing"
 
 
 class ParallelConfig(BaseModel):

--- a/backend/core/tests/conftest.py
+++ b/backend/core/tests/conftest.py
@@ -41,7 +41,7 @@ class PipelineBuilder:
             inputs=[],
             outputs=[],
             tags=kwargs.get("tags", []),
-            parallel_config=ParallelConfig(type=ParallelType.EMBARASSING)
+            parallel_config=ParallelConfig(type=ParallelType.EMBARRASSING)
             if parallel
             else None,
         )

--- a/backend/core/tests/test_pipeline_graph.py
+++ b/backend/core/tests/test_pipeline_graph.py
@@ -42,7 +42,7 @@ def canonical() -> CanonicalPipeline:
         inputs=[],
         outputs=[],
         tags=[],
-        parallel_config=ParallelConfig(type=ParallelType.EMBARASSING),  # Parallel
+        parallel_config=ParallelConfig(type=ParallelType.EMBARRASSING),  # Parallel
     )
 
     op3 = CanonicalOperator(


### PR DESCRIPTION
## Summary
- rename the ParallelType embarrassing enum value to the correct identifier
- update tests to reference the corrected enum name

## Testing
- poetry run pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69306ed092a8832a82831f4902f2c8c9)