### PR TITLE
Add stop control to running HUD

### DIFF
--- a/frontend/interactEM/src/components/pipelines/hudruntimeinfo.tsx
+++ b/frontend/interactEM/src/components/pipelines/hudruntimeinfo.tsx
@@ -13,6 +13,7 @@ import {
   getDeploymentStateColor,
 } from "../../utils/deployments"
 import { RevisionButton } from "./revisionbutton"
+import { StopPipelineButton } from "./stopbutton"
 
 interface HudRuntimeInfoProps {
   deployment: PipelineDeploymentPublic | undefined
@@ -68,6 +69,9 @@ export const HudRuntimeInfo: React.FC<HudRuntimeInfoProps> = ({
           variant="filled"
         />
       </Tooltip>
+      {deployment.state === "running" && (
+        <StopPipelineButton deploymentId={deployment.id} />
+      )}
     </Stack>
   )
 }


### PR DESCRIPTION
## Summary
- add a stop pipeline control beside the runtime status chip in the HUD
- only display the stop button when viewing a running deployment in viewer mode

## Testing
- npm run lint *(fails: existing formatting/complexity issues in package.json and scripts/deduplicate-enums.ts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6930a1ccccd8832aa0148a9e00255930)