### PR TITLE
Fix image node display for small images

### DIFF
--- a/frontend/interactEM/src/components/image.tsx
+++ b/frontend/interactEM/src/components/image.tsx
@@ -21,16 +21,16 @@ const Image: React.FC<ImageProps> = ({ imageData }) => {
   const [imageSrc, setImageSrc] = useState<string | null>(null)
 
   useEffect(() => {
-    if (imageData) {
-      const url = URL.createObjectURL(
-        // TODO: Pass the MIME type with the image data
-        new Blob([imageData.buffer as ArrayBuffer], { type: "image/jpeg" }),
-      )
-      setImageSrc(url)
+    if (!imageData) return
 
-      return () => {
-        URL.revokeObjectURL(url)
-      }
+    const url = URL.createObjectURL(
+      // TODO: Pass the MIME type with the image data
+      new Blob([imageData], { type: "image/jpeg" }),
+    )
+    setImageSrc(url)
+
+    return () => {
+      URL.revokeObjectURL(url)
     }
   }, [imageData])
 


### PR DESCRIPTION
## Summary
- create image blobs directly from the received image bytes to avoid stale data when image size changes
- skip blob creation when no image data is available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6931b3f4ea38832a92ab40cb6bb1f593)