### PR TITLE
[#382] create Blob from imageData buffer correctly

### DIFF
--- a/frontend/interactEM/src/components/image.tsx
+++ b/frontend/interactEM/src/components/image.tsx
@@ -24,7 +24,7 @@ const Image: React.FC<ImageProps> = ({ imageData }) => {
     if (imageData) {
       const url = URL.createObjectURL(
         // TODO: Pass the MIME type with the image data
-        new Blob([imageData.buffer as ArrayBuffer], { type: "image/jpeg" }),
+        new Blob([new Uint8Array(imageData)], { type: "image/jpeg" }),
       )
       setImageSrc(url)
 


### PR DESCRIPTION
Use the raw imageData when constructing the Blob instead of
casting imageData.buffer to ArrayBuffer. The change fixes incorrect
buffer usage that could produce empty or malformed image Blobs in
the preview component. This ensures URL.createObjectURL receives a
valid Blob and restores image rendering in the interactEM image
component.