### PR TITLE
add span for MUI warning

### DIFF
--- a/frontend/interactEM/src/components/pipelines/revisionbutton.tsx
+++ b/frontend/interactEM/src/components/pipelines/revisionbutton.tsx
@@ -19,34 +19,36 @@ export const RevisionButton = forwardRef<
 
   return (
     <Tooltip title={isDisabled ? undefined : "View Revision History"}>
-      <Box
-        ref={ref}
-        component="button"
-        onClick={onClick}
-        disabled={isDisabled}
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          bgcolor: "rgba(0, 0, 0, 0.05)",
-          borderRadius: "4px",
-          px: 0.8,
-          py: 0.2,
-          color: "text.secondary",
-          fontSize: "0.8em",
-          border: "none",
-          cursor: isDisabled ? "default" : "pointer",
-          opacity: isDisabled ? 0.6 : 1,
-          transition: "background-color 0.2s ease-in-out",
-          "&:hover:not(:disabled)": {
-            bgcolor: "rgba(0, 0, 0, 0.1)",
-          },
-        }}
-      >
-        <Box component="span" sx={{ mr: 0.5, display: "flex" }}>
-          <CommitIcon fontSize="small" />
+      <span>
+        <Box
+          ref={ref}
+          component="button"
+          onClick={onClick}
+          disabled={isDisabled}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            bgcolor: "rgba(0, 0, 0, 0.05)",
+            borderRadius: "4px",
+            px: 0.8,
+            py: 0.2,
+            color: "text.secondary",
+            fontSize: "0.8em",
+            border: "none",
+            cursor: isDisabled ? "default" : "pointer",
+            opacity: isDisabled ? 0.6 : 1,
+            transition: "background-color 0.2s ease-in-out",
+            "&:hover:not(:disabled)": {
+              bgcolor: "rgba(0, 0, 0, 0.1)",
+            },
+          }}
+        >
+          <Box component="span" sx={{ mr: 0.5, display: "flex" }}>
+            <CommitIcon fontSize="small" />
+          </Box>
+          {revisionId}
         </Box>
-        {revisionId}
-      </Box>
+      </span>
     </Tooltip>
   )
 })


### PR DESCRIPTION
MUI: You are providing a disabled `button` child to the Tooltip 
component.
A disabled element does not fire events.
Tooltip needs to listen to the child element's events to display the 
title.

Add a simple wrapper element, such as a `span`.