### PR TITLE
add longer timeout for deployment publishes

### DIFF
--- a/backend/core/interactem/core/constants/__init__.py
+++ b/backend/core/interactem/core/constants/__init__.py
@@ -10,7 +10,11 @@ We should ideally keep these short, nats recommends <16 tokens (hierarchy levels
 ref: https://github.com/nats-io/nats.docs/blob/master/nats-concepts/subjects.md
 """
 
+# NATS timeouts
 NATS_TIMEOUT_DEFAULT = 10
+# Deployment publishes can contend when many operators start at once; give JetStream
+# more time to acknowledge those messages.
+NATS_TIMEOUT_DEPLOYMENT = 120
 
 # Streams/buckets
 BUCKET_STATUS = "stat"

--- a/backend/core/interactem/core/nats/publish.py
+++ b/backend/core/interactem/core/nats/publish.py
@@ -14,6 +14,7 @@ from ..constants import (
     ASSIGNMENTS,
     NATS_API_KEY_HEADER,
     NATS_TIMEOUT_DEFAULT,
+    NATS_TIMEOUT_DEPLOYMENT,
     STREAM_DEPLOYMENTS,
     STREAM_IMAGES,
     STREAM_PARAMETERS,
@@ -146,7 +147,7 @@ async def publish_pipeline_to_operators(
         subject=f"{SUBJECT_OPERATORS_DEPLOYMENTS}.{operator_id}",
         message=pipeline.to_runtime().model_dump_json(),
         stream=STREAM_DEPLOYMENTS,
-        timeout=NATS_TIMEOUT_DEFAULT,
+        timeout=NATS_TIMEOUT_DEPLOYMENT,
     )
 
 def create_agent_mount_publisher(


### PR DESCRIPTION
If we don’t have a longer timeout, messages won’t be acked and a
timeout err is raised. This happen when we have a lot of operators to
bring up and they take a long time from beginning to end.