### PR TITLE
fix(ui): stringify parameter type and default in tooltip

### DIFF
--- a/frontend/interactEM/src/components/nodes/parameterinfotooltip.tsx
+++ b/frontend/interactEM/src/components/nodes/parameterinfotooltip.tsx
@@ -22,10 +22,10 @@ const ParameterInfoTooltip: React.FC<ParameterInfoTooltipProps> = ({
           </Typography>
           <Box sx={{ mt: 1 }}>
             <Typography variant="caption" component="div">
-              <strong>Type:</strong> {parameter.type}
+              <strong>Type:</strong> {String(parameter.type)}
             </Typography>
             <Typography variant="caption" component="div">
-              <strong>Default:</strong> {parameter.default}
+              <strong>Default:</strong> {String(parameter.default)}
             </Typography>
             <Typography variant="caption" component="div">
               <strong>Required:</strong> {parameter.required ? "Yes" : "No"}


### PR DESCRIPTION
helps with this issue:

type: Invalid prop `children` supplied to `ForwardRef(Typography2)`, expected a
 ReactNode.