### PR TITLE
Gate local base pushes when building operators remotely

### DIFF
--- a/operators/bake.sh
+++ b/operators/bake.sh
@@ -72,21 +72,23 @@ if $BUILD_BASE; then
     echo "=== Building base images ==="
     "${base_cmd[@]}" base --file "$BAKE_FILE" \
         --file "$BASE_VARS"
-    
-    "${base_cmd[@]}" base --file "$BAKE_FILE" \
-        --file "$OPERATORS_DIR/vars-local.hcl" --set "*.output=type=registry,oci-mediatypes=true"
 
     "${base_cmd[@]}" operator --file "$BAKE_FILE" \
         --file "$BASE_VARS"
 
-    "${base_cmd[@]}" operator --file "$BAKE_FILE" \
-        --file "$OPERATORS_DIR/vars-local.hcl" --set "*.output=type=registry,oci-mediatypes=true"
-
     "${base_cmd[@]}" distiller-streaming --file "$BAKE_FILE" \
         --file "$BASE_VARS"
 
-    "${base_cmd[@]}" distiller-streaming --file "$BAKE_FILE" \
-        --file "$OPERATORS_DIR/vars-local.hcl" --set "*.output=type=registry,oci-mediatypes=true"
+    if $PUSH_LOCAL; then
+        "${base_cmd[@]}" base --file "$BAKE_FILE" \
+            --file "$OPERATORS_DIR/vars-local.hcl" --set "*.output=type=registry,oci-mediatypes=true"
+
+        "${base_cmd[@]}" operator --file "$BAKE_FILE" \
+            --file "$OPERATORS_DIR/vars-local.hcl" --set "*.output=type=registry,oci-mediatypes=true"
+
+        "${base_cmd[@]}" distiller-streaming --file "$BAKE_FILE" \
+            --file "$OPERATORS_DIR/vars-local.hcl" --set "*.output=type=registry,oci-mediatypes=true"
+    fi
 fi
 
 #


### PR DESCRIPTION
## Summary
- avoid pushing base and operator images to the local registry when building with --push-remote
- keep local base builds limited to --push-local workflows

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693c81e255c4832ab5123bb0dc607d32)