### PR TITLE
remove inf loop if consumer is no longer alive

### DIFF
--- a/backend/core/interactem/core/nats/__init__.py
+++ b/backend/core/interactem/core/nats/__init__.py
@@ -194,16 +194,6 @@ async def consume_messages(
         except nats.errors.TimeoutError:
             await asyncio.sleep(0.1)
             continue
-        except ServiceUnavailableError as e:
-            logger.warning(
-                f"NATS JetStream temporarily unavailable (likely during leader election): {e}. "
-                "Retrying in 1s..."
-            )
-            await asyncio.sleep(1.0)
-            continue
-        except nats.errors.ConnectionClosedError:
-            logger.error("NATS connection closed.")
-            raise
         except nats.errors.Error as e:
             # If we can't fetch messages for a nats error, try to reinitialize the consumer
             if create_consumer:


### PR DESCRIPTION
this `ServiceUnavailableError` seem to be raised if we use
consumer.fetch(), even if the nats server is fine. Let’s remove this,
and try recreating consumer indefinitely.