### PR TITLE
disable HDF5 file locking in containerfile

### DIFF
--- a/operators/distiller-counted-data-reader/Containerfile
+++ b/operators/distiller-counted-data-reader/Containerfile
@@ -1,3 +1,5 @@
 FROM distiller-streaming
 
+ENV HDF5_USE_FILE_LOCKING=FALSE
+
 COPY ./run.py /app/run.py


### PR DESCRIPTION
Set HDF5_USE_FILE_LOCKING=FALSE in the Containerfile to prevent HDF5
from attempting to use file locking inside the container. This avoids
permission and compatibility issues when the container's filesystem or
host environment does not support HDF5 file locks