### PR TITLE
Add retry for pipeline publish during operator startup

### DIFF
--- a/backend/agent/interactem/agent/agent.py
+++ b/backend/agent/interactem/agent/agent.py
@@ -12,11 +12,13 @@ import stamina
 from anyio import to_thread
 from faststream.nats import NatsBroker
 from faststream.nats.publisher.usecase import LogicPublisher
+from nats import errors as nats_errors
 from podman.domain.containers import Container
 from stamina.instrumentation import set_on_retry_hooks
 
 from interactem.core.constants import (
     INTERACTEM_IMAGE_REGISTRY,
+    NATS_TIMEOUT_DEFAULT,
     OPERATOR_ID_ENV_VAR,
     VECTOR_IMAGE,
 )
@@ -621,10 +623,23 @@ class Agent:
         if cfg.log_mount:
             operator.add_internal_mount(cfg.log_mount)
 
-        # Publish pipeline to JetStream
-        await publish_pipeline_to_operators(self.broker, self.pipeline, operator.id)
-        logger.debug(f"Published pipeline for operator {operator.id}")
-        logger.debug(f"Pipeline: {self.pipeline.to_runtime().model_dump_json()}")
+        publish_timeout = NATS_TIMEOUT_DEFAULT * 3
+        for attempt in stamina.retry_context(
+            on=nats_errors.TimeoutError, attempts=3
+        ):
+            with attempt:
+                # Publish pipeline to JetStream
+                await publish_pipeline_to_operators(
+                    self.broker,
+                    self.pipeline,
+                    operator.id,
+                    timeout=publish_timeout,
+                )
+                logger.debug(f"Published pipeline for operator {operator.id}")
+                logger.debug(
+                    f"Pipeline: {self.pipeline.to_runtime().model_dump_json()}"
+                )
+                break
 
         if cfg.ALWAYS_PULL_IMAGES:
             pull_image(client, operator.image)

--- a/backend/core/interactem/core/nats/publish.py
+++ b/backend/core/interactem/core/nats/publish.py
@@ -141,12 +141,13 @@ async def publish_pipeline_to_operators(
     broker: NatsBroker,
     pipeline: PipelineGraph,
     operator_id: RuntimeOperatorID,
+    timeout: float | None = None,
 ):
     await broker.publish(
         subject=f"{SUBJECT_OPERATORS_DEPLOYMENTS}.{operator_id}",
         message=pipeline.to_runtime().model_dump_json(),
         stream=STREAM_DEPLOYMENTS,
-        timeout=NATS_TIMEOUT_DEFAULT,
+        timeout=timeout or NATS_TIMEOUT_DEFAULT,
     )
 
 def create_agent_mount_publisher(


### PR DESCRIPTION
## Summary
- allow specifying a custom timeout when publishing pipeline deployments to operators
- add retry logic with a longer timeout when sending pipeline data during operator startup to reduce transient NATS timeouts

## Testing
- ruff check backend/agent/interactem/agent/agent.py backend/core/interactem/core/nats/publish.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6940a047afb4832a8579ccceac2ade1b)