### PR TITLE
Add cache option for counted data reader

### DIFF
--- a/operators/distiller-counted-data-reader/operator.json
+++ b/operators/distiller-counted-data-reader/operator.json
@@ -27,6 +27,14 @@
       "default": "test_file.h5",
       "description": "The file to be processed",
       "required": true
+    },
+    {
+      "name": "cache_last_file",
+      "label": "Cache last file",
+      "type": "bool",
+      "default": false,
+      "description": "Cache the last loaded file to avoid re-reading between triggers.",
+      "required": false
     }
   ],
   "triggers": [


### PR DESCRIPTION
## Summary
- add optional `cache_last_file` parameter to the distiller counted data reader operator
- cache and reuse the last loaded sparse array between triggers when enabled
- streamline cached sparse array selection to reduce branching while preserving behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6942e56103dc832a9d41ba14bff84ff1)