### PR TITLE
stop messages printing constantly in metrics microservices

### DIFF
--- a/backend/core/interactem/core/logger.py
+++ b/backend/core/interactem/core/logger.py
@@ -62,6 +62,10 @@ def get_logger(
         console_handler = logging.StreamHandler(sys.stderr if log_file else sys.stdout)
         console_handler.setFormatter(formatter)
         root_logger.addHandler(console_handler)
+
+        # Suppress noisy third-party warnings
+        logging.getLogger("nats.js.kv").setLevel(logging.ERROR)
+
         _logging_configured = True
 
     # Add file handler if requested

--- a/backend/metrics/interactem/metrics/metrics.py
+++ b/backend/metrics/interactem/metrics/metrics.py
@@ -67,7 +67,7 @@ async def metrics_watch(js: JetStreamContext, update_interval: int):
                 record_collection_error(
                     ErrorType(error_type=ErrorTypeEnum.NO_PIPELINES)
                 )
-                logger.info("No pipelines found...")
+                logger.debug("No pipelines found...")
                 await asyncio.sleep(update_interval)
                 continue
 


### PR DESCRIPTION
Get rid of these types of prints...

```
                                                                                                                             
  2025-12-19T18:40:52.747+00:00 - interactem.metrics.metrics - INFO - No pipelines found...                                  
                                                                                                                             
  2025-12-19T18:40:53.761+00:00 - nats.js.kv - WARNING - Server may ignore filters if version is < 2.10.   
```