### PR TITLE
Change distiller sparse data reader

### DIFF
--- a/operators/distiller-counted-data-reader/operator.json
+++ b/operators/distiller-counted-data-reader/operator.json
@@ -32,9 +32,9 @@
       "name": "file_suffix",
       "label": "File suffix",
       "type": "str-enum",
-      "default": "STANDARD",
-      "options": ["STANDARD", "CENTERED"],
-      "description": "The file suffix type.",
+      "default": "",
+      "options": ["", "CENTERED"],
+      "description": "The file suffix type. The default is empty.",
       "required": true
     },
     {

--- a/operators/distiller-counted-data-reader/run.py
+++ b/operators/distiller-counted-data-reader/run.py
@@ -34,7 +34,7 @@ def reader(
     global current_scan_id, cached_sparse_array
 
     scan_id = parameters.get("scan_id", None)
-    file_suffix = FileSuffix(parameters.get("file_suffix", "STANDARD"))
+    file_suffix = FileSuffix(parameters.get("file_suffix", ""))
     batch_size_mb = parameters.get("batch_size_mb", 1.0)
     cache_last_file = parameters.get("cache_last_file", False)
 


### PR DESCRIPTION
Use `scan_id` and `get_scan_path` to find data in a directory. Also update some comments which were indicating this was for raw (.data) files.