### PR TITLE
clarify docker permission check message

### DIFF
--- a/scripts/check-docker-permission.sh
+++ b/scripts/check-docker-permission.sh
@@ -4,7 +4,8 @@
 if ! docker ps > /dev/null 2>&1; then
 	echo "Error: Unable to run 'docker ps' as current user" >&2
 	echo "" >&2
-	echo "You have two options:" >&2
+	echo "Is the docker daemon running? Check that first" >&2
+	echo "Otherwise you have two options:" >&2
 	echo "1. Run docker commands with sudo (e.g., 'sudo make docker-up')" >&2
 	echo "2. Configure Docker to run without sudo by following: https://docs.docker.com/engine/install/linux-postinstall/" >&2
 	echo "" >&2


### PR DESCRIPTION
Improve error guidance when 'docker ps' fails by first asking
the user to verify that the Docker daemon is running. This makes
the root cause (daemon not running) more explicit before offering
the two remediation options (use sudo or configure Docker for
non-root usage). Update messaging to reduce confusion and help
users troubleshoot more quickly.