### PR TITLE
Revert "docs: clarify README token usage and remove stray blank"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 <https://github.com/user-attachments/assets/85b669af-e4c6-4fe6-9ad3-b5cce26b1a08>
 
+
 ## Features
 
 - **Interactive Web Frontend**: Create data pipelines with a React-based frontend.
@@ -43,7 +44,7 @@
     GITHUB_TOKEN=your_personal_token
     ```
 
-    You can get a personal token from your [GitHub account settings](https://github.com/settings/tokens). Use a classic token with `read:packages`. This is optional, but required if you want to pull image information from the ghcr.io/nersc/interactem registry.
+    You can get a personal token from your [GitHub account settings](https://github.com/settings/tokens). Use a classic token with `read:packages`.
 
 ### Starting services
 
@@ -51,7 +52,7 @@
 
     ```bash
     make setup
-    # (optional) fix your GITHUB_USERNAME/TOKEN in .env
+    # then fix your GITHUB_USERNAME/TOKEN in .env
     make docker-up
     make operators
     ```


### PR DESCRIPTION
Reverts NERSC/interactEM#497

I should have made these changes inside of the `docs` dir...