### PR TITLE
pass line number to error handler in update-locks

### DIFF
--- a/scripts/update-locks.sh
+++ b/scripts/update-locks.sh
@@ -6,10 +6,10 @@ GIT_ROOT_DIR=$(git rev-parse --show-toplevel)
 FAILED_DIR=""
 
 # Error handler
-trap 'error_handler' ERR
+trap 'error_handler ${LINENO:-"unknown"}' ERR
 
 error_handler() {
-    local line_num=$1
+    local line_num=${1:-"unknown"}
     echo "❌ Error in $FAILED_DIR at line $line_num" >&2
     exit 1
 }


### PR DESCRIPTION
- Forward the current line number to the error handler in scripts/update-locks.sh via trap.
- Default the handler's line info to "unknown" when no argument is provided.
- Prevent printing empty or incorrect line information in non-interactive or unexpected contexts.
- Improve clarity of error messages and make debugging easier.