### PR TITLE
NATS auth generation update for clarity and exporting sys account for mgmt

### DIFF
--- a/conf/nats-conf/generate-auth-jwt.sh
+++ b/conf/nats-conf/generate-auth-jwt.sh
@@ -27,6 +27,7 @@ exec > >(tee -i ${THIS_DIR}/out_jwt/output.log) 2>&1
 export NSC_WORK_DIR="/tmp/interactem-nsc-auth"
 export XDG_CONFIG_HOME="${NSC_WORK_DIR}/config"
 export XDG_DATA_HOME="${NSC_WORK_DIR}/data"
+export NKEYS_PATH="${XDG_DATA_HOME}/nats/nsc/keys"
 
 rm -rf "$NSC_WORK_DIR"
 mkdir -p "$NSC_WORK_DIR"


### PR DESCRIPTION
Summary
- Ensure output directory creation when missing.
- Export system account credentials (.creds) for management.
- Make base64 operations compatible with both GNU and macOS (-i and -o flags).
- Simplify exports to only include .creds files; leave signing keys in other encoded directories.
- Copy only auth.conf, data/, and config/ into raw_output.
- Improve variable names and add more informative comments and print statements.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #523 
- <kbd>&nbsp;1&nbsp;</kbd> #522 👈 
<!-- GitButler Footer Boundary Bottom -->

