### PR TITLE
only return a message if reconstruction successful

### DIFF
--- a/operators/quantem-direct-ptycho/run.py
+++ b/operators/quantem-direct-ptycho/run.py
@@ -265,7 +265,6 @@ def quantem_direct_ptycho(
         logger.exception(
             f"Direct ptychography reconstruction failed for scan {scan_number}: {e}"
         )
-        return
     finally:
         if QUANTEM_DEVICE == "gpu":
             try:


### PR DESCRIPTION
quantem-direct-ptycho operator used to return zeros if the reconstruction failed. It now returns None instead to avoid firing downstream operators.