### PR TITLE
set the UV_CACHE_DIR to /tmp to avoid cache problems on compute nodes

### DIFF
--- a/backend/launcher/interactem/launcher/templates/launch_agent.sh.j2
+++ b/backend/launcher/interactem/launcher/templates/launch_agent.sh.j2
@@ -1,5 +1,7 @@
 {% include "header.sh.j2" %}
 
 export HDF5_USE_FILE_LOCKING=FALSE
+export UV_CACHE_DIR="${TMPDIR:-/tmp}/uv-cache-${SLURM_JOB_ID:-$$}"
+mkdir -p "$UV_CACHE_DIR"
 cd {{settings.ENV_FILE_DIR}}
 srun --nodes={{job.num_nodes}} --ntasks-per-node=1 uv run --project {{settings.AGENT_PROJECT_DIR}} interactem-agent

--- a/backend/launcher/tests/expected_script.sh
+++ b/backend/launcher/tests/expected_script.sh
@@ -15,5 +15,7 @@
 #SBATCH --exclusive
 
 export HDF5_USE_FILE_LOCKING=FALSE
+export UV_CACHE_DIR="${TMPDIR:-/tmp}/uv-cache-${SLURM_JOB_ID:-$$}"
+mkdir -p "$UV_CACHE_DIR"
 cd /path/to/.env
 srun --nodes=2 --ntasks-per-node=1 uv run --project /path/to/interactEM/backend/agent interactem-agent


### PR DESCRIPTION
```sh
error: Could not acquire lock  Caused by: Could not acquire lock for
`~/.cache/uv` at `~/.cache/uv/.lock`  Caused by:
failed to lock `~/.cache/uv/.lock`: Unknown error
524 (os error 524)
```