### PR TITLE
hydrate node-local storage prior to running a podman-hpc pull

### DIFF
--- a/backend/launcher/interactem/launcher/templates/launch_agent.sh.j2
+++ b/backend/launcher/interactem/launcher/templates/launch_agent.sh.j2
@@ -4,4 +4,7 @@ export HDF5_USE_FILE_LOCKING=FALSE
 export UV_CACHE_DIR="${TMPDIR:-/tmp}/uv-cache-${SLURM_JOB_ID:-$$}"
 mkdir -p "$UV_CACHE_DIR"
 cd {{settings.ENV_FILE_DIR}}
+
+# Pull an image to hydrate the graph root
+srun --nodes={{job.num_nodes}} --ntasks-per-node=1 uv run --project {{settings.AGENT_PROJECT_DIR}} podman-hpc pull alpine:latest
 srun --nodes={{job.num_nodes}} --ntasks-per-node=1 uv run --project {{settings.AGENT_PROJECT_DIR}} interactem-agent

--- a/backend/launcher/tests/expected_script.sh
+++ b/backend/launcher/tests/expected_script.sh
@@ -18,4 +18,7 @@ export HDF5_USE_FILE_LOCKING=FALSE
 export UV_CACHE_DIR="${TMPDIR:-/tmp}/uv-cache-${SLURM_JOB_ID:-$$}"
 mkdir -p "$UV_CACHE_DIR"
 cd /path/to/.env
+
+# Pull an image to hydrate the graph root
+srun --nodes=2 --ntasks-per-node=1 uv run --project /path/to/interactEM/backend/agent podman-hpc pull alpine:latest
 srun --nodes=2 --ntasks-per-node=1 uv run --project /path/to/interactEM/backend/agent interactem-agent


### PR DESCRIPTION
we were getting the following err:
```
RuntimeError: Failed to pull image
docker.io/timberio/vector:0.50.0-alpine: [Errno 2] No such file or
directory: '/tmp/XXXXX_hpc/storage/overlay-layers/layers.json'
```
this solves this by enabling the RW store on compute nodes

closes #545 